### PR TITLE
adding bslstl::bad_optional_access exception

### DIFF
--- a/groups/bsl/bslstl/bslstl_badoptionalaccess.cpp
+++ b/groups/bsl/bslstl/bslstl_badoptionalaccess.cpp
@@ -1,0 +1,28 @@
+// bslstl_badoptionalaccess.cpp                                       -*-C++-*-
+#include <bslstl_badoptionalaccess.h>
+
+#include <bsls_ident.h>
+BSLS_IDENT("$Id$ $CSID$")
+
+namespace BloombergLP {
+
+namespace bslstl {
+
+}  // close package namespace
+}  // close enterprise namespace
+
+// ----------------------------------------------------------------------------
+// Copyright 2020 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/groups/bsl/bslstl/bslstl_badoptionalaccess.cpp
+++ b/groups/bsl/bslstl/bslstl_badoptionalaccess.cpp
@@ -4,13 +4,6 @@
 #include <bsls_ident.h>
 BSLS_IDENT("$Id$ $CSID$")
 
-namespace BloombergLP {
-
-namespace bslstl {
-
-}  // close package namespace
-}  // close enterprise namespace
-
 // ----------------------------------------------------------------------------
 // Copyright 2020 Bloomberg Finance L.P.
 //

--- a/groups/bsl/bslstl/bslstl_badoptionalaccess.h
+++ b/groups/bsl/bslstl/bslstl_badoptionalaccess.h
@@ -8,64 +8,43 @@ BSLS_IDENT("$Id: $")
 //@PURPOSE: Provide an exception class thrown by 'bsl::optional'.
 //
 //@CLASSES:
-//  bslstl::BadOptionalAccess: exception possibly thrown by 'bsl::optional'
-//  bsl::bad_optional_access: alias to exception type thrown by 'bsl::optional'
+//  bsl::bad_optional_access: exception type thrown by 'bsl::optional'
 //
 //@SEE_ALSO: bslstl_optional, bslstl_stdexceptionutil
 //
-//@DESCRIPTION: This component provides a 'bsl::bad_optional_access' exception.
-// This exception is thrown by  'bsl::optional::value' when accessing a
+//@DESCRIPTION: This component provides a 'bsl::bad_optional_access' exception
+// class.  This exception is thrown by 'bsl::optional::value' when accessing a
 // 'bsl::optional' object that does not contain a value.  If 'std::optional'
 // implementation is available, 'bsl::bad_optional_access' is an alias to
-// 'std::bad_optional_access'.  Otherwise, it is an alias to
-// 'bslstl::BadOptionalAccess' class.
+// 'std::bad_optional_access'.
 //
 
-// Prevent 'bslstl' headers from being included directly in 'BSL_OVERRIDES_STD'
-// mode.  Doing so is unsupported, and is likely to cause compilation errors.
-#if defined(BSL_OVERRIDES_STD) && !defined(BOS_STDHDRS_PROLOGUE_IN_EFFECT)
-#error "include <bsl_memory.h> instead of <bslstl_badoptionalaccess.h> in \
-BSL_OVERRIDES_STD mode"
-#endif
 #include <bslscm_version.h>
 
 #include <bsls_exceptionutil.h>
 #include <bsls_keyword.h>
-#include <bsls_nativestd.h>
 
 #include <exception>
 
-#ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
-#include <optional> // 'std::bad_optional_access' if defined
-#endif // BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+#ifdef BDE_BUILD_TARGET_EXC
 
-namespace BloombergLP {
-namespace bslstl { class BadOptionalAccess; }
-}  // close enterprise namespace
+#ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+#include <optional> // for 'std::bad_optional_access'
+#endif // BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
 
 namespace bsl {
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
 typedef std::bad_optional_access bad_optional_access;
 #else
-typedef ::BloombergLP::bslstl::BadOptionalAccess bad_optional_access;
-#endif //BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+                       // =========================
+                       // class bad_optional_access
+                       // =========================
 
-}  // close namespace bsl
-
-#ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
-#else
-namespace BloombergLP {
-namespace bslstl {
-
-                       // =======================
-                       // class BadOptionalAccess
-                       // =======================
-
-class BadOptionalAccess : public native_std::exception {
+class bad_optional_access : public std::exception {
   public:
     // CREATORS
-    BadOptionalAccess() BSLS_KEYWORD_NOEXCEPT;
-        // Create a 'BadOptionalAccess' object.  Note that this function is
+    bad_optional_access() BSLS_KEYWORD_NOEXCEPT;
+        // Create a 'bad_optional_access' object.  Note that this function is
         // explicitly user-declared, to make it simple to declare 'const'
         // objects of this type.
 
@@ -84,25 +63,26 @@ class BadOptionalAccess : public native_std::exception {
 //                           INLINE DEFINITIONS
 // ============================================================================
 
-                       // -----------------------
-                       // class BadOptionalAccess
-                       // -----------------------
+                       // -------------------------
+                       // class bad_optional_access
+                       // -------------------------
 
 inline
-BadOptionalAccess::BadOptionalAccess() BSLS_KEYWORD_NOEXCEPT
-: native_std::exception()
+bad_optional_access::bad_optional_access() BSLS_KEYWORD_NOEXCEPT
+: std::exception()
 {
 }
 
 inline
-const char *BadOptionalAccess::what() const BSLS_EXCEPTION_WHAT_NOTHROW
+const char *bad_optional_access::what() const BSLS_EXCEPTION_WHAT_NOTHROW
 {
     return "bad_optional_access";
 }
-
-}  // close package namespace
-}  // close enterprise namespace
 #endif //BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+
+}  // close namespace bsl
+
+#endif //BDE_BUILD_TARGET_EXC
 #endif
 
 // ----------------------------------------------------------------------------

--- a/groups/bsl/bslstl/bslstl_badoptionalaccess.h
+++ b/groups/bsl/bslstl/bslstl_badoptionalaccess.h
@@ -1,0 +1,122 @@
+// bslstl_badoptionalaccess.h                                         -*-C++-*-
+#ifndef INCLUDED_BSLSTL_BADOPTIONALACCESS
+#define INCLUDED_BSLSTL_BADOPTIONALACCESS
+
+#include <bsls_ident.h>
+BSLS_IDENT("$Id: $")
+
+//@PURPOSE: Provide an exception class thrown by 'bsl::optional'.
+//
+//@CLASSES:
+//  bslstl::BadOptionalAccess: exception possibly thrown by 'bsl::optional'
+//  bsl::bad_optional_access: alias to exception type thrown by 'bsl::optional'
+//
+//@SEE_ALSO: bslstl_optional, bslstl_stdexceptionutil
+//
+//@DESCRIPTION: This component provides a 'bsl::bad_optional_access' exception.
+// This exception is thrown by  'bsl::optional::value' when accessing a
+// 'bsl::optional' object that does not contain a value.  If 'std::optional'
+// implementation is available, 'bsl::bad_optional_access' is an alias to
+// 'std::bad_optional_access'.  Otherwise, it is an alias to
+// 'bslstl::BadOptionalAccess' class.
+//
+
+// Prevent 'bslstl' headers from being included directly in 'BSL_OVERRIDES_STD'
+// mode.  Doing so is unsupported, and is likely to cause compilation errors.
+#if defined(BSL_OVERRIDES_STD) && !defined(BOS_STDHDRS_PROLOGUE_IN_EFFECT)
+#error "include <bsl_memory.h> instead of <bslstl_badoptionalaccess.h> in \
+BSL_OVERRIDES_STD mode"
+#endif
+#include <bslscm_version.h>
+
+#include <bsls_exceptionutil.h>
+#include <bsls_keyword.h>
+#include <bsls_nativestd.h>
+
+#include <exception>
+
+#ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+#include <optional> // 'std::bad_optional_access' if defined
+#endif // BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+
+namespace BloombergLP {
+namespace bslstl { class BadOptionalAccess; }
+}  // close enterprise namespace
+
+namespace bsl {
+#ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+typedef std::bad_optional_access bad_optional_access;
+#else
+typedef ::BloombergLP::bslstl::BadOptionalAccess bad_optional_access;
+#endif //BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+
+}  // close namespace bsl
+
+#ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+#else
+namespace BloombergLP {
+namespace bslstl {
+
+                       // =======================
+                       // class BadOptionalAccess
+                       // =======================
+
+class BadOptionalAccess : public native_std::exception {
+  public:
+    // CREATORS
+    BadOptionalAccess() BSLS_KEYWORD_NOEXCEPT;
+        // Create a 'BadOptionalAccess' object.  Note that this function is
+        // explicitly user-declared, to make it simple to declare 'const'
+        // objects of this type.
+
+    // ACCESSORS
+    const char *what() const BSLS_EXCEPTION_WHAT_NOTHROW BSLS_KEYWORD_OVERRIDE;
+        // Return a pointer to the string literal "bad_optional_access", with a
+        // storage duration of the lifetime of the program.  Note that the
+        // caller should *not* attempt to free this memory.  Note that the
+        // 'bsls_exceptionutil' macro 'BSLS_NOTHROW_SPEC' is deliberately not
+        // used here, as a number of standard libraries declare 'what' in the
+        // base 'exception' class explicitly with the no-throw specification,
+        // even in a build that may not recognize exceptions.
+};
+
+// ============================================================================
+//                           INLINE DEFINITIONS
+// ============================================================================
+
+                       // -----------------------
+                       // class BadOptionalAccess
+                       // -----------------------
+
+inline
+BadOptionalAccess::BadOptionalAccess() BSLS_KEYWORD_NOEXCEPT
+: native_std::exception()
+{
+}
+
+inline
+const char *BadOptionalAccess::what() const BSLS_EXCEPTION_WHAT_NOTHROW
+{
+    return "bad_optional_access";
+}
+
+}  // close package namespace
+}  // close enterprise namespace
+#endif //BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+#endif
+
+// ----------------------------------------------------------------------------
+// Copyright 2020 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/groups/bsl/bslstl/bslstl_badoptionalaccess.t.cpp
+++ b/groups/bsl/bslstl/bslstl_badoptionalaccess.t.cpp
@@ -22,13 +22,12 @@ using namespace BloombergLP;
 // 'std::bad_optional_access' exception is available, we need to check that
 // 'bsl::bad_optional_access' is a typedef to the standard's exception type.
 // If 'std::bad_optional_access' exception isn't available, we need to check
-// that 'bsl::bad_optional_access' is a typedef to the
-// 'bslstl::BadOptionalAccess' type, and that 'bslstl::BadOptionalAccess'
-// satisfies the interface and contract of 'std::bad_optional_access'.
+// that 'bsl::bad_optional_access' satisfies the interface and contract of
+// 'std::bad_optional_access'.
 //
 // ----------------------------------------------------------------------------
 // creators:
-// [ 3] BadOptionalAccess();
+// [ 3] bad_optional_access();
 //
 // accessors:
 // [ 3] const char *what() const;
@@ -119,39 +118,28 @@ int main(int argc, char *argv[])
     printf("TEST " __FILE__ " CASE %d\n", test);
 
     switch (test) { case 0:
+#ifdef BDE_BUILD_TARGET_EXC
       case 4: {
         // --------------------------------------------------------------------
-        // 'bsl::bad_optional_access' TYPE
+        // 'bsl::bad_optional_access' TYPEDEF
         //
         // Concerns:
         //: 1 The 'bsl::bad_optional_access' is a typedef for
-        //:   'bslstl::BadOptionalAccess' if 'std::bad_optional_access' isn't
-        //:   available.
-        //: 2 The 'bsl::bad_optional_access' is a typedef for
         //:   'std::bad_optional_access' if 'std::bad_optional_access' is
         //:    available.
         //
         // Plan:
         //: 1 For concern 1, if we're using CPP17 library, check that
         //:   'bsl::bad_optional_access' is the same type as
-        //:   'bslstl::BadOptionalAccess' using 'bsl::is_same'.
-        //: 2 For concern 2, if we're using CPP17 library, check that
-        //:   'bsl::bad_optional_access' is the same type as
         //:   'std::bad_optional_access' using 'bsl::is_same'.
         //
         // Testing:
         //   typedef bsl::bad_optional_access
         // --------------------------------------------------------------------
-        if (verbose) printf("\n'bsl::bad_optional_access' TYPE"
-                            "\n===============================\n");
+        if (verbose) printf("\n'bsl::bad_optional_access' TYPEDEF"
+                            "\n==================================\n");
 
-#ifndef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
-
-        ASSERT((bsl::is_same<bsl::bad_optional_access,
-                             bslstl::BadOptionalAccess>::value));
-
-#else
-
+#ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
         ASSERT((bsl::is_same<bsl::bad_optional_access,
                              std::bad_optional_access>::value));
 
@@ -162,28 +150,30 @@ int main(int argc, char *argv[])
         // DEFAULT CONSTRUCTION AND 'what' METHOD
         //
         // Concerns:
-        //: 1 A 'BadOptionalAccess' object can be default constructed.
-        //: 2 Invoking a 'what' method on a 'BadOptionalAccess' object returns
-        //:   a "bad_optional_access" string.
-        //: 3 'what' method can be invoked on a const 'BadOptionalAccess'
-        //:   object
+        //: 1 A 'bad_optional_access' object can be default constructed.
+        //: 2 Invoking a 'what' method on a 'bad_optional_access' object
+        //:   returns a "bad_optional_access" string.
+        //: 3 'what' method can be invoked on a const 'bad_optional_access'
+        //:   object.
         //
         // Plan:
-        //: 1 For concern 1, default construct a 'BadOptionalAccess' object.
-        //: 2 For concern 2, invoke the 'what' method on a 'BadOptionalAccess'
-        //:   object and check that the returned string is
-        //:   "bad_optional_access".
+        //: 1 For concern 1, default construct a 'bad_optional_access' object.
+        //: 2 For concern 2, invoke the 'what' method on a
+        //:   'bad_optional_access' object and check that the returned string
+        //:   is "bad_optional_access".
         //: 3 For concern 3, in step 2, use a const qualified
-        //:   'BadOptionalAccess' object.
+        //:   'bad_optional_access' object.
         //
         // Testing:
-        //   BadOptionalAccess();
+        //   bad_optional_access();
         //   const char *what() const;
         // --------------------------------------------------------------------
         if (verbose) printf("\nDEFAULT CONSTRUCTION AND 'what' METHOD"
                             "\n======================================\n");
 #ifndef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
-        const bslstl::BadOptionalAccess b;
+        // string returned by 'what()' method is implementation specific so we
+        // can only check our own implementation
+        const bsl::bad_optional_access b;
         ASSERT(0 == strcmp("bad_optional_access", b.what()));
 #endif // #ifndef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
 
@@ -194,16 +184,16 @@ int main(int argc, char *argv[])
         //
         // Concerns:
         //: 1 The 'noexcept' specification has been applied to
-        //:   'BadOptionalAccess' constructor as required by the standard.
+        //:   'bad_optional_access' constructor as required by the standard.
         //: 2 The 'noexcept' specification has been applied to
-        //:   'BadOptionalAccess' 'what' method as required by the standard.
+        //:   'bad_optional_access' 'what' method as required by the standard.
         // Plan:
-        //: 1 Apply the unary 'noexcept' operator to a 'BadOptionalAccess'
+        //: 1 Apply the unary 'noexcept' operator to a 'bad_optional_access'
         //:   constructor and, for concern 1, confirm that calculated boolean
         //:   value matches the expected value.
-        //: 2 Apply the unary 'noexcept' operator to 'BadOptionalAccess' 'what'
-        //:   method and, for concern 2,  confirm that calculated boolean value
-        //:   matches the expected value.
+        //: 2 Apply the unary 'noexcept' operator to 'bad_optional_access'
+        //:   'what' method and, for concern 2, confirm that calculated boolean
+        //:   value matches the expected value.
         //
         // Testing:
         //   CONCERN: Methods qualified 'noexcept' in standard are so.
@@ -222,10 +212,13 @@ int main(int argc, char *argv[])
         //     } // namespace std
         //..
 #ifndef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+        // While noexcept specification is a standard requirement, at least one
+        // library implementation does not apply the noexcept specification
+        // correctly.
         ASSERT(BSLS_KEYWORD_NOEXCEPT_AVAILABLE
-            == BSLS_KEYWORD_NOEXCEPT_OPERATOR(bslstl::BadOptionalAccess()));
+            == BSLS_KEYWORD_NOEXCEPT_OPERATOR(bsl::bad_optional_access()));
 
-        bslstl::BadOptionalAccess    b;
+        bsl::bad_optional_access b;
         ASSERT(BSLS_KEYWORD_NOEXCEPT_AVAILABLE
             == BSLS_KEYWORD_NOEXCEPT_OPERATOR(b.what()));
 #endif
@@ -248,21 +241,13 @@ int main(int argc, char *argv[])
 
         if (verbose) printf("\nBREATHING TEST"
                             "\n==============\n");
-#ifndef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
-        bslstl::BadOptionalAccess    b;
-        const native_std::exception *ptr = &b;
+        bsl::bad_optional_access  b;
+        const std::exception     *ptr = &b;
 
-        ASSERT(0 == strcmp("bad_optional_access", b.what()));
-        ASSERT(0 == strcmp("bad_optional_access", ptr->what()));
-#endif
-
-        const bsl::bad_optional_access b2;
-        const native_std::exception *ptr2 = &b2;
-
-        ASSERT(0 != b2.what());
-        ASSERT(0 != ptr2->what());
-
-      }break;
+        ASSERT(0 != b.what());
+        ASSERT(0 != ptr->what());
+      } break;
+#endif //BDE_BUILD_TARGET_EXC
       default: {
             fprintf(stderr, "WARNING: CASE `%d' NOT FOUND.\n", test);
             testStatus = -1;

--- a/groups/bsl/bslstl/bslstl_badoptionalaccess.t.cpp
+++ b/groups/bsl/bslstl/bslstl_badoptionalaccess.t.cpp
@@ -1,0 +1,292 @@
+// bslstl_badoptionalaccess.t.cpp                                     -*-C++-*-
+#include <bslstl_badoptionalaccess.h>
+
+#include <bslmf_issame.h>
+
+#include <bsls_asserttest.h>
+#include <bsls_bsltestutil.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+using namespace BloombergLP;
+
+// ============================================================================
+//                             TEST PLAN
+// ----------------------------------------------------------------------------
+//                             Overview
+//                             --------
+// The type under test is 'bsl::bad_optional_access', an exception type whose
+// interface and contract is dictated by the C++ standard.  If
+// 'std::bad_optional_access' exception is available, we need to check that
+// 'bsl::bad_optional_access' is a typedef to the standard's exception type.
+// If 'std::bad_optional_access' exception isn't available, we need to check
+// that 'bsl::bad_optional_access' is a typedef to the
+// 'bslstl::BadOptionalAccess' type, and that 'bslstl::BadOptionalAccess'
+// satisfies the interface and contract of 'std::bad_optional_access'.
+//
+// ----------------------------------------------------------------------------
+// creators:
+// [ 3] BadOptionalAccess();
+//
+// accessors:
+// [ 3] const char *what() const;
+//
+// typedef:
+// [ 4] typedef bsl::bad_optional_access
+// ----------------------------------------------------------------------------
+// [ 1] BREATHING TEST
+// [ 2] CONCERN: Methods qualified 'noexcept' in standard are so.
+
+// ============================================================================
+//                     STANDARD BSL ASSERT TEST FUNCTION
+// ----------------------------------------------------------------------------
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        printf("Error " __FILE__ "(%d): %s    (failed)\n", line, message);
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+// ============================================================================
+//               STANDARD BSL TEST DRIVER MACRO ABBREVIATIONS
+// ----------------------------------------------------------------------------
+
+#define ASSERT       BSLS_BSLTESTUTIL_ASSERT
+#define ASSERTV      BSLS_BSLTESTUTIL_ASSERTV
+
+#define LOOP_ASSERT  BSLS_BSLTESTUTIL_LOOP_ASSERT
+#define LOOP0_ASSERT BSLS_BSLTESTUTIL_LOOP0_ASSERT
+#define LOOP1_ASSERT BSLS_BSLTESTUTIL_LOOP1_ASSERT
+#define LOOP2_ASSERT BSLS_BSLTESTUTIL_LOOP2_ASSERT
+#define LOOP3_ASSERT BSLS_BSLTESTUTIL_LOOP3_ASSERT
+#define LOOP4_ASSERT BSLS_BSLTESTUTIL_LOOP4_ASSERT
+#define LOOP5_ASSERT BSLS_BSLTESTUTIL_LOOP5_ASSERT
+#define LOOP6_ASSERT BSLS_BSLTESTUTIL_LOOP6_ASSERT
+
+#define Q            BSLS_BSLTESTUTIL_Q   // Quote identifier literally.
+#define P            BSLS_BSLTESTUTIL_P   // Print identifier and value.
+#define P_           BSLS_BSLTESTUTIL_P_  // P(X) without '\n'.
+#define T_           BSLS_BSLTESTUTIL_T_  // Print a tab (w/o newline).
+#define L_           BSLS_BSLTESTUTIL_L_  // current Line number
+
+#define RUN_EACH_TYPE BSLTF_TEMPLATETESTFACILITY_RUN_EACH_TYPE
+
+// ============================================================================
+//                  NEGATIVE-TEST MACRO ABBREVIATIONS
+// ----------------------------------------------------------------------------
+
+#define ASSERT_SAFE_PASS(EXPR) BSLS_ASSERTTEST_ASSERT_SAFE_PASS(EXPR)
+#define ASSERT_SAFE_FAIL(EXPR) BSLS_ASSERTTEST_ASSERT_SAFE_FAIL(EXPR)
+#define ASSERT_PASS(EXPR)      BSLS_ASSERTTEST_ASSERT_PASS(EXPR)
+#define ASSERT_FAIL(EXPR)      BSLS_ASSERTTEST_ASSERT_FAIL(EXPR)
+#define ASSERT_OPT_PASS(EXPR)  BSLS_ASSERTTEST_ASSERT_OPT_PASS(EXPR)
+#define ASSERT_OPT_FAIL(EXPR)  BSLS_ASSERTTEST_ASSERT_OPT_FAIL(EXPR)
+
+//=============================================================================
+//                         GLOBAL FUNCTIONS FOR TESTING
+//-----------------------------------------------------------------------------
+
+//=============================================================================
+//                             USAGE EXAMPLE
+//-----------------------------------------------------------------------------
+
+//=============================================================================
+//                              MAIN PROGRAM
+//-----------------------------------------------------------------------------
+
+int main(int argc, char *argv[])
+{
+
+    int  test                = argc > 1 ? atoi(argv[1]) : 0;
+    bool verbose             = argc > 2;
+//  bool veryVerbose         = argc > 3;
+//  bool veryVeryVerbose     = argc > 4;
+//  bool veryVeryVeryVerbose = argc > 5;
+
+    printf("TEST " __FILE__ " CASE %d\n", test);
+
+    switch (test) { case 0:
+      case 4: {
+        // --------------------------------------------------------------------
+        // 'bsl::bad_optional_access' TYPE
+        //
+        // Concerns:
+        //: 1 The 'bsl::bad_optional_access' is a typedef for
+        //:   'bslstl::BadOptionalAccess' if 'std::bad_optional_access' isn't
+        //:   available.
+        //: 2 The 'bsl::bad_optional_access' is a typedef for
+        //:   'std::bad_optional_access' if 'std::bad_optional_access' is
+        //:    available.
+        //
+        // Plan:
+        //: 1 For concern 1, if we're using CPP17 library, check that
+        //:   'bsl::bad_optional_access' is the same type as
+        //:   'bslstl::BadOptionalAccess' using 'bsl::is_same'.
+        //: 2 For concern 2, if we're using CPP17 library, check that
+        //:   'bsl::bad_optional_access' is the same type as
+        //:   'std::bad_optional_access' using 'bsl::is_same'.
+        //
+        // Testing:
+        //   typedef bsl::bad_optional_access
+        // --------------------------------------------------------------------
+        if (verbose) printf("\n'bsl::bad_optional_access' TYPE"
+                            "\n===============================\n");
+
+#ifndef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+
+        ASSERT((bsl::is_same<bsl::bad_optional_access,
+                             bslstl::BadOptionalAccess>::value));
+
+#else
+
+        ASSERT((bsl::is_same<bsl::bad_optional_access,
+                             std::bad_optional_access>::value));
+
+#endif //BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+      } break;
+      case 3: {
+        // --------------------------------------------------------------------
+        // DEFAULT CONSTRUCTION AND 'what' METHOD
+        //
+        // Concerns:
+        //: 1 A 'BadOptionalAccess' object can be default constructed.
+        //: 2 Invoking a 'what' method on a 'BadOptionalAccess' object returns
+        //:   a "bad_optional_access" string.
+        //: 3 'what' method can be invoked on a const 'BadOptionalAccess'
+        //:   object
+        //
+        // Plan:
+        //: 1 For concern 1, default construct a 'BadOptionalAccess' object.
+        //: 2 For concern 2, invoke the 'what' method on a 'BadOptionalAccess'
+        //:   object and check that the returned string is
+        //:   "bad_optional_access".
+        //: 3 For concern 3, in step 2, use a const qualified
+        //:   'BadOptionalAccess' object.
+        //
+        // Testing:
+        //   BadOptionalAccess();
+        //   const char *what() const;
+        // --------------------------------------------------------------------
+        if (verbose) printf("\nDEFAULT CONSTRUCTION AND 'what' METHOD"
+                            "\n======================================\n");
+#ifndef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+        const bslstl::BadOptionalAccess b;
+        ASSERT(0 == strcmp("bad_optional_access", b.what()));
+#endif // #ifndef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+
+      } break;
+      case 2: {
+        // --------------------------------------------------------------------
+        // 'noexcept' SPECIFICATION
+        //
+        // Concerns:
+        //: 1 The 'noexcept' specification has been applied to
+        //:   'BadOptionalAccess' constructor as required by the standard.
+        //: 2 The 'noexcept' specification has been applied to
+        //:   'BadOptionalAccess' 'what' method as required by the standard.
+        // Plan:
+        //: 1 Apply the unary 'noexcept' operator to a 'BadOptionalAccess'
+        //:   constructor and, for concern 1, confirm that calculated boolean
+        //:   value matches the expected value.
+        //: 2 Apply the unary 'noexcept' operator to 'BadOptionalAccess' 'what'
+        //:   method and, for concern 2,  confirm that calculated boolean value
+        //:   matches the expected value.
+        //
+        // Testing:
+        //   CONCERN: Methods qualified 'noexcept' in standard are so.
+        // --------------------------------------------------------------------
+
+        if (verbose) printf("\n'noexcept' SPECIFICATION"
+                            "\n========================\n");
+
+        // N4835: 20.6.5 Class 'bad_optional_access' [optional.bad.access]
+        //..
+        //     namespace std {
+        //       class bad_optional_access: public std::exception {
+        //       public:
+        //         const char* what() const noexcept override;
+        //       };
+        //     } // namespace std
+        //..
+#ifndef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+        ASSERT(BSLS_KEYWORD_NOEXCEPT_AVAILABLE
+            == BSLS_KEYWORD_NOEXCEPT_OPERATOR(bslstl::BadOptionalAccess()));
+
+        bslstl::BadOptionalAccess    b;
+        ASSERT(BSLS_KEYWORD_NOEXCEPT_AVAILABLE
+            == BSLS_KEYWORD_NOEXCEPT_OPERATOR(b.what()));
+#endif
+      } break;
+      case 1: {
+        // --------------------------------------------------------------------
+        // BREATHING TEST
+        //   This case exercises (but does not fully test) basic functionality.
+        //
+        // Concerns:
+        //: 1 The class is sufficiently functional to enable comprehensive
+        //:   testing in subsequent test cases.
+        //
+        // Plan:
+        //: 1 Perform and ad-hoc test of the primary modifiers and accessors.
+        //
+        // Testing:
+        //   BREATHING TEST
+        // --------------------------------------------------------------------
+
+        if (verbose) printf("\nBREATHING TEST"
+                            "\n==============\n");
+#ifndef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+        bslstl::BadOptionalAccess    b;
+        const native_std::exception *ptr = &b;
+
+        ASSERT(0 == strcmp("bad_optional_access", b.what()));
+        ASSERT(0 == strcmp("bad_optional_access", ptr->what()));
+#endif
+
+        const bsl::bad_optional_access b2;
+        const native_std::exception *ptr2 = &b2;
+
+        ASSERT(0 != b2.what());
+        ASSERT(0 != ptr2->what());
+
+      }break;
+      default: {
+            fprintf(stderr, "WARNING: CASE `%d' NOT FOUND.\n", test);
+            testStatus = -1;
+      }
+    }
+
+    if (testStatus > 0) {
+        fprintf(stderr, "Error, non-zero test status = %d.\n", testStatus);
+    }
+    return testStatus;
+}
+
+// ----------------------------------------------------------------------------
+// Copyright 2020 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/groups/bsl/bslstl/package/bslstl.mem
+++ b/groups/bsl/bslstl/package/bslstl.mem
@@ -2,6 +2,7 @@ bslstl_algorithmworkaround
 bslstl_allocator
 bslstl_allocatortraits
 bslstl_array
+bslstl_badoptionalaccess
 bslstl_badweakptr
 bslstl_bidirectionaliterator
 bslstl_bidirectionalnodepool


### PR DESCRIPTION
Implementation of bslstl::bad_optional_access exception needed for implementation of bsl::optional::value()