### PR TITLE
bslstl_optional_internals

### DIFF
--- a/groups/bsl/bslstl/bslstl_inplace.cpp
+++ b/groups/bsl/bslstl/bslstl_inplace.cpp
@@ -1,0 +1,22 @@
+// bslstl_inplace.cpp                                                 -*-C++-*-
+
+#include <bslstl_inplace.h>
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(bslstl_inplacet_cpp, "$Id$ $CSID$")
+
+// ----------------------------------------------------------------------------
+// Copyright 2020 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/groups/bsl/bslstl/bslstl_inplace.cpp
+++ b/groups/bsl/bslstl/bslstl_inplace.cpp
@@ -1,9 +1,8 @@
 // bslstl_inplace.cpp                                                 -*-C++-*-
-
 #include <bslstl_inplace.h>
 
 #include <bsls_ident.h>
-BSLS_IDENT_RCSID(bslstl_inplacet_cpp, "$Id$ $CSID$")
+BSLS_IDENT_RCSID(bslstl_inplace_cpp, "$Id$ $CSID$")
 
 // ----------------------------------------------------------------------------
 // Copyright 2020 Bloomberg Finance L.P.

--- a/groups/bsl/bslstl/bslstl_inplace.cpp
+++ b/groups/bsl/bslstl/bslstl_inplace.cpp
@@ -3,7 +3,13 @@
 
 #include <bsls_ident.h>
 BSLS_IDENT_RCSID(bslstl_inplace_cpp, "$Id$ $CSID$")
+namespace bsl {
 
+#if !defined(BSLS_COMPILERFEATURES_SUPPORT_CONSTEXPR)
+const in_place_t in_place = in_place_t();
+#endif
+
+}  // close namespace bsl
 // ----------------------------------------------------------------------------
 // Copyright 2020 Bloomberg Finance L.P.
 //

--- a/groups/bsl/bslstl/bslstl_inplace.h
+++ b/groups/bsl/bslstl/bslstl_inplace.h
@@ -18,8 +18,8 @@ BSLS_IDENT("$Id: $")
 // two other in-place construction tag types, 'std::in_place_type_t' and
 // 'std::in_place_index_t'. There is currently no need to provide the
 // equivalent tag types in bsl, but if such need arises, the name of this
-// header has been chosen for the purpose of being the designated place for
-// all in-place construction tags.
+// header has been chosen for the purpose of being the designated place for all
+// in-place construction tags.
 
 #include <bslscm_version.h>
 

--- a/groups/bsl/bslstl/bslstl_inplace.h
+++ b/groups/bsl/bslstl/bslstl_inplace.h
@@ -46,15 +46,17 @@ struct in_place_t {
     // contain a single object to indicate that the contained object should be
     // constructed in-place.
 
+    // CREATORS
     explicit BSLS_KEYWORD_CONSTEXPR in_place_t() BSLS_KEYWORD_NOEXCEPT;
         // Create an 'in_place_t' value.
 };
 
-// bde_verify requires an out-of-class definition.  The 'constexpr' 'in_place'
-// variable requires a constructor definition before its own definition below.
+// CREATORS
 inline
 BSLS_KEYWORD_CONSTEXPR in_place_t::in_place_t() BSLS_KEYWORD_NOEXCEPT
 {
+    // This 'constexpr' function has to be defined before initialializing the
+    // 'constexpr' value, 'in_place', below.
 }
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_CONSTEXPR)

--- a/groups/bsl/bslstl/bslstl_inplace.h
+++ b/groups/bsl/bslstl/bslstl_inplace.h
@@ -1,5 +1,4 @@
 // bslstl_inplace.h                                                   -*-C++-*-
-
 #ifndef INCLUDED_BSLSTL_INPLACE
 #define INCLUDED_BSLSTL_INPLACE
 
@@ -13,7 +12,7 @@ BSLS_IDENT("$Id: $")
 //
 //@DESCRIPTION: This component provides an implementation of a standard
 // compliant tag type for in-place construction, 'bsl::in_place_t'.  This tag
-// type is used in constructors of bsl::optional to indicate that the contained
+// type is used in constructors of 'bsl::optional' to indicate that the contained
 // object should be constructed in-place.  Note that the standard currently has
 // two other in-place construction tag types, 'std::in_place_type_t' and
 // 'std::in_place_index_t'. There is currently no need to provide the
@@ -57,6 +56,7 @@ static const BSLS_KEYWORD_CONSTEXPR in_place_t in_place = in_place_t();
 }  // close namespace bsl
 
 #endif  // INCLUDED_BSLSTL_INPLACE
+
 // ----------------------------------------------------------------------------
 // Copyright 2020 Bloomberg Finance L.P.
 //

--- a/groups/bsl/bslstl/bslstl_inplace.h
+++ b/groups/bsl/bslstl/bslstl_inplace.h
@@ -26,7 +26,7 @@ BSLS_IDENT("$Id: $")
 #include <bsls_keyword.h>
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
-#include <utility> // for std::in_place_t
+#include <utility>  // for std::in_place_t
 #endif  // BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
 
 namespace bsl {

--- a/groups/bsl/bslstl/bslstl_inplace.h
+++ b/groups/bsl/bslstl/bslstl_inplace.h
@@ -1,0 +1,74 @@
+// bslstl_inplace.h                                                   -*-C++-*-
+
+#ifndef INCLUDED_BSLSTL_INPLACE
+#define INCLUDED_BSLSTL_INPLACE
+
+#include <bsls_ident.h>
+BSLS_IDENT("$Id: $")
+
+//@PURPOSE: Provide a standard-compliant in place construction tag types.
+//
+//@CLASSES:
+//  bsl::in_place_t: tag type for in-place construction
+//
+//@DESCRIPTION: This component provides an implementation of a standard
+// compliant tag type for in-place construction, 'bsl::in_place_t'.  This tag
+// type is used in constructors of bsl::optional to indicate that the contained
+// object should be constructed in-place.  Note that the standard currently has
+// two other in-place construction tag types, 'std::in_place_type_t' and
+// 'std::in_place_index_t'. There is currently no need to provide the
+// equivalent tag types in bsl, but if such need arises, the name of this
+// header has been chosen for the purpose of being the designated place for
+// all in-place construction tags.
+
+#include <bslscm_version.h>
+
+#include <bsls_compilerfeatures.h>
+#include <bsls_keyword.h>
+
+#ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+#include <utility> // for std::in_place_t
+#endif  // BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+
+namespace bsl {
+
+#ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+
+using in_place_t = std::in_place_t;
+using std::in_place;
+
+#else
+
+                              // ================
+                              // class in_place_t
+                              // ================
+struct in_place_t {
+    // This trivial tag type is passed to the constructors of types that
+    // contain a single object to indicate that the contained object should be
+    // constructed in-place.
+};
+
+static const BSLS_KEYWORD_CONSTEXPR in_place_t in_place = in_place_t();
+// Value of type 'in_place_t' used as an argument to functions that take an
+// 'in_place_t' argument.
+
+#endif  // BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+
+}  // close namespace bsl
+
+#endif  // INCLUDED_BSLSTL_INPLACE
+// ----------------------------------------------------------------------------
+// Copyright 2020 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/groups/bsl/bslstl/bslstl_inplace.h
+++ b/groups/bsl/bslstl/bslstl_inplace.h
@@ -12,13 +12,13 @@ BSLS_IDENT("$Id: $")
 //
 //@DESCRIPTION: This component provides an implementation of a standard
 // compliant tag type for in-place construction, 'bsl::in_place_t'.  This tag
-// type is used in constructors of 'bsl::optional' to indicate that the contained
-// object should be constructed in-place.  Note that the standard currently has
-// two other in-place construction tag types, 'std::in_place_type_t' and
-// 'std::in_place_index_t'. There is currently no need to provide the
-// equivalent tag types in bsl, but if such need arises, the name of this
-// header has been chosen for the purpose of being the designated place for all
-// in-place construction tags.
+// type is used in constructors of 'bsl::optional' to indicate that the
+// contained object should be constructed in-place.  Note that the standard
+// currently has two other in-place construction tag types,
+// 'std::in_place_type_t' and 'std::in_place_index_t'. There is currently no
+// need to provide the equivalent tag types in bsl, but if such need arises,
+// the name of this header has been chosen for the purpose of being the
+// designated place for all in-place construction tags.
 
 #include <bslscm_version.h>
 
@@ -45,7 +45,17 @@ struct in_place_t {
     // This trivial tag type is passed to the constructors of types that
     // contain a single object to indicate that the contained object should be
     // constructed in-place.
+
+    explicit BSLS_KEYWORD_CONSTEXPR in_place_t() BSLS_KEYWORD_NOEXCEPT;
+        // Create an 'in_place_t' value.
 };
+
+// bde_verify requires an out-of-class definition.  The 'constexpr' 'in_place'
+// variable requires a constructor definition before its own definition below.
+inline
+BSLS_KEYWORD_CONSTEXPR in_place_t::in_place_t() BSLS_KEYWORD_NOEXCEPT
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_CONSTEXPR)
 BSLS_KEYWORD_INLINE_CONSTEXPR in_place_t in_place = in_place_t();

--- a/groups/bsl/bslstl/bslstl_inplace.h
+++ b/groups/bsl/bslstl/bslstl_inplace.h
@@ -47,9 +47,13 @@ struct in_place_t {
     // constructed in-place.
 };
 
-static const BSLS_KEYWORD_CONSTEXPR in_place_t in_place = in_place_t();
-// Value of type 'in_place_t' used as an argument to functions that take an
-// 'in_place_t' argument.
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_CONSTEXPR)
+BSLS_KEYWORD_INLINE_CONSTEXPR in_place_t in_place = in_place_t();
+#else
+extern const in_place_t in_place;
+#endif
+    // Value of type 'in_place_t' used as an argument to functions that take an
+    // 'in_place_t' argument.
 
 #endif  // BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
 

--- a/groups/bsl/bslstl/bslstl_inplace.t.cpp
+++ b/groups/bsl/bslstl/bslstl_inplace.t.cpp
@@ -1,0 +1,201 @@
+// bslstl_inplace.t.cpp                                               -*-C++-*-
+
+#include <bsls_bsltestutil.h>
+#include <bsls_platform.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "bslstl_inplace.h"
+
+using namespace BloombergLP;
+using namespace bsl;
+
+// ============================================================================
+//                             TEST PLAN
+// ----------------------------------------------------------------------------
+//                             Overview
+//                             --------
+// The type under test is 'bsl::in_place_t', a trivial tag type whose interface
+// and contract is dictated by the C++ standard.  If 'std::in_place_t' is
+// available, we need to check that 'bsl::in_place_t' is a typedef to the
+// standard's tag type.  If 'std::in_place_t' isn't available, we need to check
+// that 'bsl::in_place_t' satisfies the interface and contract of
+// 'std::in_place_t'.
+//
+//
+// ----------------------------------------------------------------------------
+// typedef:
+// [ 2] typedef bsl::in_place_t
+// ----------------------------------------------------------------------------
+// [ 1] BREATHING TEST
+
+// ============================================================================
+//                     STANDARD BSL ASSERT TEST FUNCTION
+// ----------------------------------------------------------------------------
+
+namespace {
+
+int testStatus = 0;
+
+void aSsErT(bool condition, const char *message, int line)
+{
+    if (condition) {
+        printf("Error " __FILE__ "(%d): %s    (failed)\n", line, message);
+
+        if (0 <= testStatus && testStatus <= 100) {
+            ++testStatus;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+
+// ============================================================================
+//               STANDARD BSL TEST DRIVER MACRO ABBREVIATIONS
+// ----------------------------------------------------------------------------
+
+#define ASSERT       BSLS_BSLTESTUTIL_ASSERT
+#define ASSERTV      BSLS_BSLTESTUTIL_ASSERTV
+
+#define LOOP_ASSERT  BSLS_BSLTESTUTIL_LOOP_ASSERT
+#define LOOP0_ASSERT BSLS_BSLTESTUTIL_LOOP0_ASSERT
+#define LOOP1_ASSERT BSLS_BSLTESTUTIL_LOOP1_ASSERT
+#define LOOP2_ASSERT BSLS_BSLTESTUTIL_LOOP2_ASSERT
+#define LOOP3_ASSERT BSLS_BSLTESTUTIL_LOOP3_ASSERT
+#define LOOP4_ASSERT BSLS_BSLTESTUTIL_LOOP4_ASSERT
+#define LOOP5_ASSERT BSLS_BSLTESTUTIL_LOOP5_ASSERT
+#define LOOP6_ASSERT BSLS_BSLTESTUTIL_LOOP6_ASSERT
+
+#define Q            BSLS_BSLTESTUTIL_Q   // Quote identifier literally.
+#define P            BSLS_BSLTESTUTIL_P   // Print identifier and value.
+#define P_           BSLS_BSLTESTUTIL_P_  // P(X) without '\n'.
+#define T_           BSLS_BSLTESTUTIL_T_  // Print a tab (w/o newline).
+#define L_           BSLS_BSLTESTUTIL_L_  // current Line number
+
+// ============================================================================
+//                  NEGATIVE-TEST MACRO ABBREVIATIONS
+// ----------------------------------------------------------------------------
+
+#define ASSERT_SAFE_PASS(EXPR) BSLS_ASSERTTEST_ASSERT_SAFE_PASS(EXPR)
+#define ASSERT_SAFE_FAIL(EXPR) BSLS_ASSERTTEST_ASSERT_SAFE_FAIL(EXPR)
+#define ASSERT_PASS(EXPR)      BSLS_ASSERTTEST_ASSERT_PASS(EXPR)
+#define ASSERT_FAIL(EXPR)      BSLS_ASSERTTEST_ASSERT_FAIL(EXPR)
+#define ASSERT_OPT_PASS(EXPR)  BSLS_ASSERTTEST_ASSERT_OPT_PASS(EXPR)
+#define ASSERT_OPT_FAIL(EXPR)  BSLS_ASSERTTEST_ASSERT_OPT_FAIL(EXPR)
+
+
+//=============================================================================
+//                         GLOBAL FUNCTIONS FOR TESTING
+//-----------------------------------------------------------------------------
+
+// Return 'true' if invoked with an object of type 'bsl::in_place_t', and
+// 'false' otherwise.
+bool isInplaceTagType(const bsl::in_place_t&)
+{
+    return true;
+}
+template<class TYPE>
+bool isInplaceTagType(const TYPE &)
+{
+    return false;
+}
+
+//=============================================================================
+//                             USAGE EXAMPLE
+//-----------------------------------------------------------------------------
+
+//=============================================================================
+//                              MAIN PROGRAM
+//-----------------------------------------------------------------------------
+
+int main(int argc, char *argv[])
+{
+
+    int  test                = argc > 1 ? atoi(argv[1]) : 0;
+    bool verbose             = argc > 2;
+//  bool veryVerbose         = argc > 3;
+//  bool veryVeryVerbose     = argc > 4;
+//  bool veryVeryVeryVerbose = argc > 5;
+
+    printf("TEST " __FILE__ " CASE %d\n", test);
+
+    switch (test) { case 0:
+      case 2: {
+        // --------------------------------------------------------------------
+        // 'bsl::in_place_t' TYPEDEF
+        //
+        // Concerns:
+        //: 1 The 'bsl::in_place_t' is a typedef for 'std::in_place_t' if
+        //:   'std::in_place_t' is available.
+        //
+        // Plan:
+        //: 1 For concern 1, if we're using CPP17 library, check that
+        //:   'bsl::in_place_t' is the same type as 'std::in_place_t' using
+        //:   'bsl::is_same'.
+        //
+        // Testing:
+        //   typedef bsl::in_place_t
+        // --------------------------------------------------------------------
+        if (verbose) printf("\n'bsl::in_place_t' TYPEDEF"
+                            "\n=========================\n");
+
+  #ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+        ASSERT((bsl::is_same<bsl::in_place_t, std::in_place_t>::value));
+
+  #endif //BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+      } break;
+      case 1: {
+        // --------------------------------------------------------------------
+        // BREATHING TEST
+        //   This case exercises basic functionality.
+        //
+        // Concerns:
+        //: 1 The class is sufficiently functional and 'bsl::in_place' variable
+        //:   exists
+        //
+        // Plan:
+        //: 1 Perform and ad-hoc test of the primary modifiers and accessors.
+        //
+        // Testing:
+        //   BREATHING TEST
+        // --------------------------------------------------------------------
+
+        if (verbose) printf("\nBREATHING TEST"
+                            "\n==============\n");
+
+        bsl::in_place_t b;
+
+        ASSERT(isInplaceTagType(b));
+        ASSERT(isInplaceTagType(bsl::in_place));
+
+      } break;
+      default: {
+            fprintf(stderr, "WARNING: CASE `%d' NOT FOUND.\n", test);
+            testStatus = -1;
+      }
+    }
+
+    if (testStatus > 0) {
+        fprintf(stderr, "Error, non-zero test status = %d.\n", testStatus);
+    }
+    return testStatus;
+}
+
+// ----------------------------------------------------------------------------
+// Copyright 2020 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------
+
+

--- a/groups/bsl/bslstl/bslstl_inplace.t.cpp
+++ b/groups/bsl/bslstl/bslstl_inplace.t.cpp
@@ -130,7 +130,9 @@ int main(int argc, char *argv[])
         //:   'std::in_place_t' is available.
         //
         // Plan:
-        //: 1 Check that 'bsl::in_place_t' is the same type as 'std::in_place_t' using 'bsl::is_same' if CPP17 library is available (C-1).
+        //: 1 Check that 'bsl::in_place_t' is the same type as
+        //:   'std::in_place_t' using 'bsl::is_same' if CPP17 library is
+        //:   available (C-1).
         //
         // Testing:
         //   typedef bsl::in_place_t

--- a/groups/bsl/bslstl/bslstl_inplace.t.cpp
+++ b/groups/bsl/bslstl/bslstl_inplace.t.cpp
@@ -1,6 +1,7 @@
 // bslstl_inplace.t.cpp                                               -*-C++-*-
 
 #include <bslstl_inplace.h>
+
 #include <bsls_bsltestutil.h>
 #include <bsls_platform.h>
 
@@ -139,7 +140,6 @@ int main(int argc, char *argv[])
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
         ASSERT((bsl::is_same<bsl::in_place_t, std::in_place_t>::value));
-
 #endif  //BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
       } break;
       case 1: {

--- a/groups/bsl/bslstl/bslstl_inplace.t.cpp
+++ b/groups/bsl/bslstl/bslstl_inplace.t.cpp
@@ -1,9 +1,9 @@
 // bslstl_inplace.t.cpp                                               -*-C++-*-
 
+#include <bslstl_inplace.h>
 #include <bsls_bsltestutil.h>
 #include <bsls_platform.h>
 
-#include "bslstl_inplace.h"
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/groups/bsl/bslstl/bslstl_inplace.t.cpp
+++ b/groups/bsl/bslstl/bslstl_inplace.t.cpp
@@ -1,9 +1,9 @@
 // bslstl_inplace.t.cpp                                               -*-C++-*-
 
+#include <bslstl_inplace.h>
 #include <bsls_bsltestutil.h>
 #include <bsls_platform.h>
 
-#include "bslstl_inplace.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -129,9 +129,7 @@ int main(int argc, char *argv[])
         //:   'std::in_place_t' is available.
         //
         // Plan:
-        //: 1 For concern 1, if we're using CPP17 library, check that
-        //:   'bsl::in_place_t' is the same type as 'std::in_place_t' using
-        //:   'bsl::is_same'.
+        //: 1 Check that 'bsl::in_place_t' is the same type as 'std::in_place_t' using 'bsl::is_same' if CPP17 library is available (C-1).
         //
         // Testing:
         //   typedef bsl::in_place_t
@@ -151,7 +149,7 @@ int main(int argc, char *argv[])
         //
         // Concerns:
         //: 1 The class is sufficiently functional and 'bsl::in_place' variable
-        //:   exists
+        //:   exists.
         //
         // Plan:
         //: 1 Perform and ad-hoc test of the primary modifiers and accessors.

--- a/groups/bsl/bslstl/bslstl_inplace.t.cpp
+++ b/groups/bsl/bslstl/bslstl_inplace.t.cpp
@@ -3,9 +3,9 @@
 #include <bsls_bsltestutil.h>
 #include <bsls_platform.h>
 
+#include "bslstl_inplace.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "bslstl_inplace.h"
 
 using namespace BloombergLP;
 using namespace bsl;
@@ -95,8 +95,8 @@ bool isInplaceTagType(const bsl::in_place_t&)
 {
     return true;
 }
-template<class TYPE>
-bool isInplaceTagType(const TYPE &)
+template <class TYPE>
+bool isInplaceTagType(const TYPE&)
 {
     return false;
 }
@@ -111,12 +111,11 @@ bool isInplaceTagType(const TYPE &)
 
 int main(int argc, char *argv[])
 {
-
-    int  test                = argc > 1 ? atoi(argv[1]) : 0;
-    bool verbose             = argc > 2;
-//  bool veryVerbose         = argc > 3;
-//  bool veryVeryVerbose     = argc > 4;
-//  bool veryVeryVeryVerbose = argc > 5;
+    int  test    = argc > 1 ? atoi(argv[1]) : 0;
+    bool verbose = argc > 2;
+    //  bool veryVerbose         = argc > 3;
+    //  bool veryVeryVerbose     = argc > 4;
+    //  bool veryVeryVeryVerbose = argc > 5;
 
     printf("TEST " __FILE__ " CASE %d\n", test);
 
@@ -140,10 +139,10 @@ int main(int argc, char *argv[])
         if (verbose) printf("\n'bsl::in_place_t' TYPEDEF"
                             "\n=========================\n");
 
-  #ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+#ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
         ASSERT((bsl::is_same<bsl::in_place_t, std::in_place_t>::value));
 
-  #endif //BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+#endif  //BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
       } break;
       case 1: {
         // --------------------------------------------------------------------
@@ -171,8 +170,8 @@ int main(int argc, char *argv[])
 
       } break;
       default: {
-            fprintf(stderr, "WARNING: CASE `%d' NOT FOUND.\n", test);
-            testStatus = -1;
+        fprintf(stderr, "WARNING: CASE `%d' NOT FOUND.\n", test);
+        testStatus = -1;
       }
     }
 
@@ -197,5 +196,3 @@ int main(int argc, char *argv[])
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ----------------------------- END-OF-FILE ----------------------------------
-
-

--- a/groups/bsl/bslstl/bslstl_optional.cpp
+++ b/groups/bsl/bslstl/bslstl_optional.cpp
@@ -5,6 +5,23 @@
 #include <bsls_ident.h>
 BSLS_IDENT_RCSID(bslstl_optional_cpp, "$Id$ $CSID$")
 
+namespace bsl {
+
+#if !defined(BSLS_COMPILERFEATURES_SUPPORT_CONSTEXPR)
+const nullopt_t nullopt = nullopt_t(0);
+#endif
+
+}  // close namespace bsl
+
+namespace BloombergLP {
+namespace bslstl {
+
+#if !defined(BSLS_COMPILERFEATURES_SUPPORT_CONSTEXPR)
+const Optional_OptNoSuchType optNoSuchType = Optional_OptNoSuchType(0);
+#endif
+
+}  // close package namespace
+}  // close enterprise namespace
 // ----------------------------------------------------------------------------
 // Copyright 2020 Bloomberg Finance L.P.
 //

--- a/groups/bsl/bslstl/bslstl_optional.cpp
+++ b/groups/bsl/bslstl/bslstl_optional.cpp
@@ -7,10 +7,10 @@
 // should not be used as an example for new development.
 // ----------------------------------------------------------------------------
 
-#include "bslstl_optional.h"
+#include <bslstl_optional.h>
 
 #include <bsls_ident.h>
-BSLS_IDENT_RCSID(bslstl_optional_cpp,"$Id$ $CSID$")
+BSLS_IDENT_RCSID(bslstl_optional_cpp, "$Id$ $CSID$")
 
 // ----------------------------------------------------------------------------
 // Copyright 2020 Bloomberg Finance L.P.

--- a/groups/bsl/bslstl/bslstl_optional.cpp
+++ b/groups/bsl/bslstl/bslstl_optional.cpp
@@ -22,6 +22,7 @@ const Optional_OptNoSuchType optNoSuchType = Optional_OptNoSuchType(0);
 
 }  // close package namespace
 }  // close enterprise namespace
+
 // ----------------------------------------------------------------------------
 // Copyright 2020 Bloomberg Finance L.P.
 //

--- a/groups/bsl/bslstl/bslstl_optional.cpp
+++ b/groups/bsl/bslstl/bslstl_optional.cpp
@@ -1,12 +1,5 @@
 // bslstl_optional.cpp                                                -*-C++-*-
 
-// ----------------------------------------------------------------------------
-//                                   NOTICE
-//
-// This component is not up to date with current BDE coding standards, and
-// should not be used as an example for new development.
-// ----------------------------------------------------------------------------
-
 #include <bslstl_optional.h>
 
 #include <bsls_ident.h>

--- a/groups/bsl/bslstl/bslstl_optional.h
+++ b/groups/bsl/bslstl/bslstl_optional.h
@@ -185,7 +185,7 @@ namespace bslstl {
                         // ============================
 
 struct Optional_OptNoSuchType {
-    // This trivial tag type is used to distinguish between arguments passed by
+    // This component-private trivial tag type is used to distinguish between arguments passed by
     // a user, and an 'enable_if' argument.  It is not default constructible so
     // the following construction never invokes a constrained single parameter
     // constructor:
@@ -225,7 +225,7 @@ extern const Optional_OptNoSuchType optNoSuchType;
 
 #else
 #define BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE bsl::is_trivially_copyable
-// C++03 does not provide a trivially destructible state.  Instead we use
+// C++03 does not provide a trivially destructible trait.  Instead we use
 // 'bsl::is_trivially_copyable' which implies the type is also trivially
 // destructible.
 #endif  // BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
@@ -646,7 +646,7 @@ struct Optional_DataImp {
 
     //ACCESSORS
     bool hasValue() const BSLS_KEYWORD_NOEXCEPT;
-        // return 'true' if there is a value in 'd_buffer', and 'false'
+        // Return 'true' if this objects has a value, and 'false'
         //otherwise.
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
@@ -1461,9 +1461,9 @@ template <class TYPE>
 void Optional_DataImp<TYPE>::reset() BSLS_KEYWORD_NOEXCEPT
 {
     if (d_hasValue) {
-        bslma::DestructionUtil::destroy(&(d_buffer.object()));
+        bslma::DestructionUtil::destroy(&d_buffer.object());
+        d_hasValue = false;
     }
-    d_hasValue = false;
 }
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
@@ -1540,16 +1540,12 @@ const TYPE& Optional_DataImp<TYPE>::value() const
 template <class TYPE, bool IS_TRIVIALLY_DESTRUCTIBLE>
 Optional_Data<TYPE, IS_TRIVIALLY_DESTRUCTIBLE>::~Optional_Data()
 {
-    this->reset();
+    reset();
 }
 
 }  // close package namespace
 }  // close enterprise namespace
 
-#undef BSLS_KEYWORD_LVREF_QUAL
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
-#undef BSLS_KEYWORD_RVREF_QUAL
-#endif
 
 #undef BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE
 

--- a/groups/bsl/bslstl/bslstl_optional.h
+++ b/groups/bsl/bslstl/bslstl_optional.h
@@ -223,9 +223,9 @@ extern const Optional_OptNoSuchType optNoSuchType;
 
 #else
 #define BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE bsl::is_trivially_copyable
-// C++03 does not provide a trivially destructible trait.  Instead we use
-// 'bsl::is_trivially_copyable' which implies the type is also trivially
-// destructible.
+    // C++03 does not provide a trivially destructible trait.  Instead we use
+    // 'bsl::is_trivially_copyable' which implies the type is also trivially
+    // destructible.
 #endif  // BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
 
                            // ======================

--- a/groups/bsl/bslstl/bslstl_optional.h
+++ b/groups/bsl/bslstl/bslstl_optional.h
@@ -161,9 +161,13 @@ BSLS_KEYWORD_CONSTEXPR nullopt_t::nullopt_t(int) BSLS_KEYWORD_NOEXCEPT
 {
 }
 
-static const BSLS_KEYWORD_CONSTEXPR nullopt_t nullopt = nullopt_t(0);
-// Value of type 'nullopt_t' used as an argument to functions that take a
-// 'nullopt_t' argument.
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_CONSTEXPR)
+BSLS_KEYWORD_INLINE_CONSTEXPR nullopt_t nullopt = nullopt_t(0);
+#else
+extern const nullopt_t nullopt;
+#endif
+    // Value of type 'nullopt_t' used as an argument to functions that take a
+    // 'nullopt_t' argument.
 
 #endif  // __cpp_lib_optional
 
@@ -208,10 +212,15 @@ BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType::Optional_OptNoSuchType(
 {
 }
 
-static const BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType optNoSuchType =
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_CONSTEXPR)
+BSLS_KEYWORD_INLINE_CONSTEXPR Optional_OptNoSuchType optNoSuchType =
     Optional_OptNoSuchType(0);
-// Value of type 'Optional_OptNoSuchType' used as the default argument in
-// functions that are constrained using a function argument.
+#else
+extern const Optional_OptNoSuchType optNoSuchType;
+#endif
+    // Value of type 'Optional_OptNoSuchType' used as the default argument in
+    // functions that are constrained using a function argument.
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
 #define BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE                             \

--- a/groups/bsl/bslstl/bslstl_optional.h
+++ b/groups/bsl/bslstl/bslstl_optional.h
@@ -153,9 +153,8 @@ struct nullopt_t {
 
 // CREATORS
 
-// bde_verify requires an out-of-class definition.  It also requires the tag
-// variable below not to be extern.  The variable itself requires a constructor
-// definition before its own definition.
+// bde_verify requires an out-of-class definition.  The 'constexpr' variable
+// requires a constructor definition before its own definition.
 inline
 BSLS_KEYWORD_CONSTEXPR nullopt_t::nullopt_t(int) BSLS_KEYWORD_NOEXCEPT
 {
@@ -203,9 +202,8 @@ struct Optional_OptNoSuchType {
 
 // CREATORS
 
-// bde_verify requires an out-of-class definition.  It also requires the tag
-// variable below not to be extern.  The variable itself requires a constructor
-// definition before its own definition.
+// bde_verify requires an out-of-class definition.  The 'constexpr' variable
+// requires a constructor definition before its own definition.
 inline
 BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType::Optional_OptNoSuchType(
                                                      int) BSLS_KEYWORD_NOEXCEPT

--- a/groups/bsl/bslstl/bslstl_optional.h
+++ b/groups/bsl/bslstl/bslstl_optional.h
@@ -232,7 +232,7 @@ struct Optional_OptNoSuchType {
     // CREATORS
     explicit BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType(
                                                     int) BSLS_KEYWORD_NOEXCEPT;
-        // Create a 'Optional_OptNoSuchType' object.  Note that the argument is
+        // Create an 'Optional_OptNoSuchType' object.  Note that the argument is
         // not used.
 };
 
@@ -269,7 +269,7 @@ static const BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType optNoSuchType =
 
 template <class TYPE>
 struct Optional_DataImp {
-    // This component-private 'class' manages a 'value_type' object in
+    // This component-private 'struct' manages a 'value_type' object in
     // 'optional'.  It allows 'optional<TYPE>' to be trivially destructible if
     // 'TYPE' is trivially destructible.  This class also provides an
     // abstraction for 'const' value type.  An 'optional' may contain a 'const'
@@ -295,7 +295,9 @@ struct Optional_DataImp {
     // DATA
     bsls::ObjectBuffer<StoredType> d_buffer;
         // in-place 'TYPE' object
-    bool d_hasValue;  // 'true' if object has a value, and 'false' otherwise
+        
+    bool                           d_hasValue;  
+        // 'true' if object has a value, and 'false' otherwise
   public:
     // CREATORS
     Optional_DataImp() BSLS_KEYWORD_NOEXCEPT;

--- a/groups/bsl/bslstl/bslstl_optional.h
+++ b/groups/bsl/bslstl/bslstl_optional.h
@@ -59,32 +59,33 @@ BSLS_IDENT("$Id: $")
 // First, create a nullable 'int' object:
 //..
 //  bsl::optional<int> optionalInt;
-//  assert( !optionalInt.has_value());
+//  assert(!optionalInt.has_value());
 //..
 // Next, give the 'int' object the value 123 (making it non-null):
 //..
 //  optionalInt.emplace(123);
-//  assert(optionalInt.has_value());
+//  assert( optionalInt.has_value());
 //  assert(123 == optionalInt.value());
 //..
 // Finally, reset the object to its default constructed state (i.e., null):
 //..
 //  optionalInt.reset();
-//  assert( !optionalInt.has_value());
+//  assert(!optionalInt.has_value());
 //..
-
-//known limitations :
-//  - For assignment/construction constraints, we use is_constructible
-//    but the exact creation will be done using allocation construction
-//    that will invoke an allocator extended constructor for allocator
-//    aware types. If the 'value_type' is constructible from the
-//    assignment/constructor parameter, but doesn't have a corresponding
-//    allocator extended constructor, the overload selection may not be
-//    be correct.
-//  - 'optional<const TYPE>' is fully supported in C++11 and onwards. However,
-//    due to limitations of 'MovableRef<const TYPE>', C++03 support for const
-//    value_types is limited and move semantics of such an 'optional' in C++03
-//    will not work.
+//
+///Known limitations
+///-----------------
+//: o For assignment/construction constraints, we use 'is_constructible' but
+//:   the exact creation will be done using allocation construction that will
+//:   invoke an allocator-extended constructor for allocator-aware types.
+//:   If the 'value_type' is constructible from the assignment/constructor
+//:   argument, but doesn't have a corresponding allocator-extended
+//:   constructor, the overload selection may not be be correct.
+//:
+//: o 'optional<const TYPE>' is fully supported in C++11 and onwards. However,
+//:   due to limitations of 'MovableRef<const TYPE>', C++03 support for const
+//:   'value_type's is limited and move semantics of such an 'optional' in
+//:   C++03 will not work.
 
 #include <bslscm_version.h>
 
@@ -238,14 +239,13 @@ static const BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType optNoSuchType =
 template <class TYPE>
 struct Optional_DataImp {
     // This component-private 'struct' manages a 'value_type' object in
-    // 'optional'.  It allows 'optional<TYPE>' to be trivially destructible if
-    // 'TYPE' is trivially destructible.  This class also provides an
+    // 'optional'.  This class provides an
     // abstraction for 'const' value type.  An 'optional' may contain a 'const'
     // type object.  An assignment to such an 'optional' should not succeed.
     // However, unless the 'optional' itself is 'const', it should be possible
     // to change the value of the 'optional' using 'emplace'.  In order to
     // allow for that, this class manages a non-const object of 'value_type',
-    // but all the observers return a 'const' adjusted reference to the managed
+    // but all the accessors return a 'const' adjusted reference to the managed
     // object.  This functionality is common for all value types and is
     // implemented in the 'Optional_DataImp' base class.  The derived class,
     // 'Optional_Data', is specialised on 'value_type'
@@ -684,23 +684,8 @@ template <class TYPE,
               BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE<TYPE>::value>
 struct Optional_Data : public Optional_DataImp<TYPE> {
     // This component-private 'struct' manages a 'value_type' object in
-    // 'optional'.  It allows 'optional<TYPE>' to be trivially destructible if
-    // 'TYPE' is trivially destructible.  This class also provides an
-    // abstraction for 'const' value type.  An 'optional' may contain a 'const'
-    // type object.  An assignment to such an 'optional' should not succeed.
-    // However, unless the 'optional' itself is 'const', it should be possible
-    // to change the value of the 'optional' using 'emplace'.  In order to
-    // allow for that, this class manages a non-const object of 'value_type',
-    // but all the observers return a 'const' adjusted reference to the managed
-    // object.  This functionality is common for all value types and is
-    // implemented in the 'Optional_DataImp' base class.  The derived class,
-    // 'Optional_Data', is specialised on 'value_type'
-    // 'is_trivially_destructible' trait.  The main template is for types that
-    // are not trivially destructible, and it provides a destructor that
-    // ensures the 'value_type' destructor is called if 'd_buffer' holds an
-    // object.  The specialisation for 'is_trivially_destructible' types does
-    // not have a user-provided destructor and 'is_trivially_destructible'
-    // itself.
+    // 'optional' by inheriting from `Optional_DataImp`.  In addition, this primary template properly
+    // destroys the owned instance of 'TYPE' in its destructor.
 
   public:
     // CREATORS
@@ -714,23 +699,8 @@ struct Optional_Data : public Optional_DataImp<TYPE> {
 
 template <class TYPE>
 struct Optional_Data<TYPE, true> : public Optional_DataImp<TYPE> {
-    // This component-private 'struct' manages a 'value_type' object in
-    // 'optional'.  It allows 'optional<TYPE>' to be trivially destructible if
-    // 'TYPE' is trivially destructible.  This class also provides an
-    // abstraction for 'const' value type.  An 'optional' may contain a 'const'
-    // type object.  An assignment to such an 'optional' should not succeed.
-    // However, unless the 'optional' itself is 'const', it should be possible
-    // to change the value of the 'optional' using 'emplace'.  In order to
-    // allow for that, this class manages a non-const object of 'value_type',
-    // but all the observers return a 'const' adjusted reference to the managed
-    // object.  This functionality is common for all value types and is
-    // implemented in the 'Optional_DataImp' base class.  The derived class,
-    // 'Optional_Data', is specialised on 'value_type'
-    // 'is_trivially_destructible' trait.  The main template is for types that
-    // are not trivially destructible, and it provides a destructor that
-    // ensures the 'value_type' destructor is called if 'd_buffer' holds an
-    // object.  This specialisation is for 'is_trivially_destructible' types,
-    // and does not have a user provided destructor, which makes it
+    // This partial specialization manages a trivially destructible 'value_type' in optional. 
+    // It does not have a user-provided destructor, which makes it
     // 'is_trivially_destructible' itself.
 
   public:

--- a/groups/bsl/bslstl/bslstl_optional.h
+++ b/groups/bsl/bslstl/bslstl_optional.h
@@ -1,12 +1,5 @@
 // bslstl_optional.h                                                  -*-C++-*-
 
-// ----------------------------------------------------------------------------
-//                                   NOTICE
-//
-// This component is not up to date with current BDE coding standards, and
-// should not be used as an example for new development.
-// ----------------------------------------------------------------------------
-
 #ifndef INCLUDED_BSLSTL_OPTIONAL
 #define INCLUDED_BSLSTL_OPTIONAL
 
@@ -119,7 +112,6 @@ BSLS_IDENT("$Id: $")
 #include "bslstl_inplace.h"
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
-//#include <bsl_type_traits.h>
 #include <type_traits>
 #endif
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY

--- a/groups/bsl/bslstl/bslstl_optional.h
+++ b/groups/bsl/bslstl/bslstl_optional.h
@@ -33,9 +33,8 @@ BSLS_IDENT("$Id: $")
 // 'reset' method will result in the optional object being disengaged.
 //
 // If the underlying 'TYPE' has value-semantics, then so will the type
-// 'bsl::optional<TYPE>'.  Two homogeneous optional objects have the same
-// value if their underlying (non-null) 'TYPE' values are the same, or both are
-// null.
+// 'bsl::optional<TYPE>'.  Two homogeneous optional objects have the same value
+// if their underlying (non-null) 'TYPE' values are the same, or both are null.
 //
 // Note that the object of template parameter 'TYPE' that is managed by a
 // 'bsl:optional<TYPE>' object is created *in*-*place*.  Consequently, the
@@ -87,8 +86,10 @@ BSLS_IDENT("$Id: $")
 //    value_types is limited and move semantics of such an 'optional' in C++03
 //    will not work.
 
-
 #include <bslscm_version.h>
+
+#include <bslstl_badoptionalaccess.h>
+
 #include <bslalg_swaputil.h>
 
 #include <bslma_constructionutil.h>
@@ -115,8 +116,6 @@ BSLS_IDENT("$Id: $")
 #include <bsls_unspecifiedbool.h>
 #include <bsls_util.h>
 
-#include <bslstl_badoptionalaccess.h>
-
 #include <stddef.h>
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
@@ -126,7 +125,7 @@ BSLS_IDENT("$Id: $")
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
 //In C++17, bsl::optional for non-aa types inherits from std::optional
 #include <optional>
-#endif // BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
+#endif  // BSLS_LIBRARYFEATURES_HAS_CPP17_BASELINE_LIBRARY
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
 #include <initializer_list>
@@ -136,7 +135,7 @@ BSLS_IDENT("$Id: $")
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
 #define BSLS_KEYWORD_LVREF_QUAL &
 #define BSLS_KEYWORD_RVREF_QUAL &&
-    // These macros represent ref-qualifiers on member functions in C++11
+// These macros represent ref-qualifiers on member functions in C++11
 #else
 #define BSLS_KEYWORD_LVREF_QUAL
 //#define BSLS_KEYWORD_RVREF_QUAL
@@ -160,55 +159,56 @@ using in_place_t = std::in_place_t;
 using std::in_place;
 #else
 
-                        // =========================
-                        // class nullopt_t
-                        // =========================
+                              // ===============
+                              // class nullopt_t
+                              // ===============
 struct nullopt_t {
-    // 'nullopt_t' is a tag type used to create 'optional' objects in a
-    // disengaged state.  It should not be default constructible so the
-    // following assignment isn't ambiguous :
+    // This trivial tag type is used to create 'optional' objects in a
+    // disengaged state.  It is not default constructible so the following
+    // assignment is unambiguous:
     //..
     //   optional<SomeType> o;
     //   o = {};
     //..
     // where 'o' is an 'optional' object.
 
-
     // CREATORS
     explicit BSLS_KEYWORD_CONSTEXPR nullopt_t(int) BSLS_KEYWORD_NOEXCEPT;
-        // constructor must be explicit to prevent accidental creation of
-        // nullopt_t objects.
+        // Create a 'nullopt_t' object.  Note that the argument is not used.
 };
 
 // CREATORS
 
-// bde_verify requires an out of class definition.  It also requires the tag
+// bde_verify requires an out-of-class definition.  It also requires the tag
 // variable below not to be extern.  The variable itself requires a constructor
 // definition before its own definition.
-inline BSLS_KEYWORD_CONSTEXPR nullopt_t::nullopt_t(int) BSLS_KEYWORD_NOEXCEPT
-{}
+inline
+BSLS_KEYWORD_CONSTEXPR nullopt_t::nullopt_t(int) BSLS_KEYWORD_NOEXCEPT
+{
+}
 
 static const BSLS_KEYWORD_CONSTEXPR nullopt_t nullopt = nullopt_t(0);
-    // Value of type 'nullopt_t' used as an argument to functions  that take
-    // an 'nullopt_t' argument.
+// Value of type 'nullopt_t' used as an argument to functions that take a
+// 'nullopt_t' argument.
 
-                        // =========================
-                        // class in_place_t
-                        // =========================
+                              // ================
+                              // class in_place_t
+                              // ================
 struct in_place_t {
-    // 'in_place_t' is a tag type that is passed to the constructors of
-    // 'optional' to indicate that the contained object should be constructed
+    // This trivial tag type is passed to the constructors of 'optional' to
+    // indicate that the contained object should be constructed
     //  in-place.
 };
 
 static const BSLS_KEYWORD_CONSTEXPR in_place_t in_place = in_place_t();
-    // Value of type 'in_place_t' used as an argument to functions  that take
-    // an 'in_place_t' argument.
+// Value of type 'in_place_t' used as an argument to functions that take an
+// 'in_place_t' argument.
 
-#endif //__cpp_lib_optional
+#endif  // __cpp_lib_optional
 
-template <class TYPE, bool USES_BSLMA_ALLOC =
-                           BloombergLP::bslma::UsesBslmaAllocator<TYPE>::value>
+template <class TYPE,
+          bool USES_BSLMA_ALLOC =
+              BloombergLP::bslma::UsesBslmaAllocator<TYPE>::value>
 class optional;
 
 }  // close namespace bsl
@@ -221,105 +221,103 @@ namespace bslstl {
                         // ============================
 
 struct Optional_OptNoSuchType {
-        // Type to distinguish between arguments passed by a user, and an
-        // 'enable_if' argument.  It should not be default constructible so
-        // the following construction never invokes a constrained single
-        // parameter constructor :
-        //..
-        //   optional<SomeType> o(int, {});
-        //..
+    // This trivial tag type is used to distinguish between arguments passed by
+    // a user, and an 'enable_if' argument.  It is not default constructible so
+    // the following construction never invokes a constrained single parameter
+    // constructor:
+    //..
+    //   optional<SomeType> o(int, {});
+    //..
 
     // CREATORS
-    explicit BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType(int)
-        BSLS_KEYWORD_NOEXCEPT;
-        // constructor must be explicit to prevent accidental creation of
-        // Optional_OptNoSuchType objects.
+    explicit BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType(
+                                                    int) BSLS_KEYWORD_NOEXCEPT;
+        // Create a 'Optional_OptNoSuchType' object.  Note that the argument is
+        // not used.
 };
 
 // CREATORS
 
-// bde_verify requires an out of class definition.  It also requires the tag
+// bde_verify requires an out-of-class definition.  It also requires the tag
 // variable below not to be extern.  The variable itself requires a constructor
 // definition before its own definition.
-inline BSLS_KEYWORD_CONSTEXPR
-Optional_OptNoSuchType::Optional_OptNoSuchType(int) BSLS_KEYWORD_NOEXCEPT
-{}
+inline
+BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType::Optional_OptNoSuchType(
+                                                     int) BSLS_KEYWORD_NOEXCEPT
+{
+}
 
 static const BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType optNoSuchType =
-                                                     Optional_OptNoSuchType(0);
-    // Value of type 'Optional_OptNoSuchType' used as the default argument in
-    // functions that are constrained using a function argument.
+    Optional_OptNoSuchType(0);
+// Value of type 'Optional_OptNoSuchType' used as the default argument in
+// functions that are constrained using a function argument.
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
 #define BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE                             \
-                                        std::is_trivially_destructible
-
+    std::is_trivially_destructible
 
 #else
 #define BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE bsl::is_trivially_copyable
-    // C++03 does not provide a trivially destructible state.  Instead we use
-    // 'bsl::is_trivially_copyable' which implies the type is also trivially
-    // destructible.
-#endif // BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
+// C++03 does not provide a trivially destructible state.  Instead we use
+// 'bsl::is_trivially_copyable' which implies the type is also trivially
+// destructible.
+#endif  // BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
 
-                        // ======================
-                        // class Optional_DataImp
-                        // ======================
+                           // ======================
+                           // class Optional_DataImp
+                           // ======================
 
 template <class TYPE>
 struct Optional_DataImp {
-    // Component-level class; DO NOT USE
-
-    // Optional_Data is a type used to manage 'value_type' object in
+    // This component-private 'class' manages a 'value_type' object in
     // 'optional'.  It allows 'optional<TYPE>' to be trivially destructible if
     // 'TYPE' is trivially destructible.  This class also provides an
-    // abstraction for const value type.  An 'optional' may contain a 'const'
+    // abstraction for 'const' value type.  An 'optional' may contain a 'const'
     // type object.  An assignment to such an 'optional' should not succeed.
     // However, unless the 'optional' itself is 'const', it should be possible
     // to change the value of the 'optional' using 'emplace'.  In order to
     // allow for that, this class manages a non-const object of 'value_type',
     // but all the observers return a 'const' adjusted reference to the managed
     // object.  This functionality is common for all value types and is
-    // implemented in the Optional_DataImp base class.  The derived class,
+    // implemented in the 'Optional_DataImp' base class.  The derived class,
     // 'Optional_Data', is specialised on 'value_type'
-    // 'is_trivially_destructible' trait.  The main template is for non
-    // trivially destructible types, and it provides a destructor that ensures
-    // the value_type destructor is called if 'd_buffer' holds an object.  The
-    // specialisation for 'is_trivially_destructible' types does not have a
-    // user provided destructor and 'is_trivially_destructible' itself.
+    // 'is_trivially_destructible' trait.  The main template is for types that
+    // are not trivially destructible, and it provides a destructor that
+    // ensures the 'value_type' destructor is called if 'd_buffer' holds an
+    // object.  The specialisation for 'is_trivially_destructible' types does
+    // not have a user-provided destructor and 'is_trivially_destructible'
+    // itself.
 
   private:
     // PRIVATE TYPES
     typedef typename bsl::remove_const<TYPE>::type StoredType;
 
-    //DATA
-    BloombergLP::bsls::ObjectBuffer<StoredType>  d_buffer;
-                 // in-place 'TYPE' object
-    bool           d_hasValue;       // 'true' if object has value, Otherwise
-                 // 'false'
+    // DATA
+    bsls::ObjectBuffer<StoredType> d_buffer;
+        // in-place 'TYPE' object
+    bool d_hasValue;  // 'true' if object has a value, and 'false' otherwise
   public:
-
     // CREATORS
     Optional_DataImp() BSLS_KEYWORD_NOEXCEPT;
-        // Creates an empty 'Optional_DataImp' object.
+        // Create an empty 'Optional_DataImp' object.
 
     // MANIPULATORS
 #if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
-    template<class... ARGS>
-    void emplace(bslma::Allocator *allocator,
+    template <class... ARGS>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)...);
         // Create an object of 'StoredType' in 'd_buffer' using the specified
         // 'allocator' and arguments.
 
-    #if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
-    template<class IL_TYPE, class... ARGS>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
+    template <class INIT_LIST_TYPE, class... ARGS>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)...);
         // Create an object of 'StoredType' in 'd_buffer' using the specified
         // 'allocator', 'initializer_list', and arguments.
 
-    #endif//BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS
+#endif  //BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS
 #elif BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // The following section is automatically generated.  **DO NOT EDIT**
@@ -331,39 +329,39 @@ struct Optional_DataImp {
 #define BSLSTL_OPTIONAL_VARIADIC_LIMIT_A BSLSTL_OPTIONAL_VARIADIC_LIMIT
 #endif
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 0
-    void emplace(bslma::Allocator *allocator);
+    void emplace(bslma::Allocator                           *allocator);
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 0
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 1
-    template<class ARGS_01>
-    void emplace(bslma::Allocator *allocator,
+    template <class ARGS_01>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01));
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 1
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 2
-    template<class ARGS_01,
-             class ARGS_02>
-    void emplace(bslma::Allocator *allocator,
+    template <class ARGS_01,
+              class ARGS_02>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02));
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 2
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 3
-    template<class ARGS_01,
-             class ARGS_02,
-             class ARGS_03>
-    void emplace(bslma::Allocator *allocator,
+    template <class ARGS_01,
+              class ARGS_02,
+              class ARGS_03>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03));
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 3
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 4
-    template<class ARGS_01,
-             class ARGS_02,
-             class ARGS_03,
-             class ARGS_04>
-    void emplace(bslma::Allocator *allocator,
+    template <class ARGS_01,
+              class ARGS_02,
+              class ARGS_03,
+              class ARGS_04>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -371,12 +369,12 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 4
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 5
-    template<class ARGS_01,
-             class ARGS_02,
-             class ARGS_03,
-             class ARGS_04,
-             class ARGS_05>
-    void emplace(bslma::Allocator *allocator,
+    template <class ARGS_01,
+              class ARGS_02,
+              class ARGS_03,
+              class ARGS_04,
+              class ARGS_05>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -385,13 +383,13 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 5
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 6
-    template<class ARGS_01,
-             class ARGS_02,
-             class ARGS_03,
-             class ARGS_04,
-             class ARGS_05,
-             class ARGS_06>
-    void emplace(bslma::Allocator *allocator,
+    template <class ARGS_01,
+              class ARGS_02,
+              class ARGS_03,
+              class ARGS_04,
+              class ARGS_05,
+              class ARGS_06>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -401,14 +399,14 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 6
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 7
-    template<class ARGS_01,
-             class ARGS_02,
-             class ARGS_03,
-             class ARGS_04,
-             class ARGS_05,
-             class ARGS_06,
-             class ARGS_07>
-    void emplace(bslma::Allocator *allocator,
+    template <class ARGS_01,
+              class ARGS_02,
+              class ARGS_03,
+              class ARGS_04,
+              class ARGS_05,
+              class ARGS_06,
+              class ARGS_07>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -419,15 +417,15 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 7
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 8
-    template<class ARGS_01,
-             class ARGS_02,
-             class ARGS_03,
-             class ARGS_04,
-             class ARGS_05,
-             class ARGS_06,
-             class ARGS_07,
-             class ARGS_08>
-    void emplace(bslma::Allocator *allocator,
+    template <class ARGS_01,
+              class ARGS_02,
+              class ARGS_03,
+              class ARGS_04,
+              class ARGS_05,
+              class ARGS_06,
+              class ARGS_07,
+              class ARGS_08>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -439,16 +437,16 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 8
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 9
-    template<class ARGS_01,
-             class ARGS_02,
-             class ARGS_03,
-             class ARGS_04,
-             class ARGS_05,
-             class ARGS_06,
-             class ARGS_07,
-             class ARGS_08,
-             class ARGS_09>
-    void emplace(bslma::Allocator *allocator,
+    template <class ARGS_01,
+              class ARGS_02,
+              class ARGS_03,
+              class ARGS_04,
+              class ARGS_05,
+              class ARGS_06,
+              class ARGS_07,
+              class ARGS_08,
+              class ARGS_09>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -461,17 +459,17 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 9
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 10
-    template<class ARGS_01,
-             class ARGS_02,
-             class ARGS_03,
-             class ARGS_04,
-             class ARGS_05,
-             class ARGS_06,
-             class ARGS_07,
-             class ARGS_08,
-             class ARGS_09,
-             class ARGS_10>
-    void emplace(bslma::Allocator *allocator,
+    template <class ARGS_01,
+              class ARGS_02,
+              class ARGS_03,
+              class ARGS_04,
+              class ARGS_05,
+              class ARGS_06,
+              class ARGS_07,
+              class ARGS_08,
+              class ARGS_09,
+              class ARGS_10>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -485,47 +483,47 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 10
 
 
-    #if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 0
-    template<class IL_TYPE>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list);
+    template <class INIT_LIST_TYPE>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list);
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 0
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 1
-    template<class IL_TYPE, class ARGS_01>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+    template <class INIT_LIST_TYPE, class ARGS_01>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01));
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 1
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 2
-    template<class IL_TYPE, class ARGS_01,
-                            class ARGS_02>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+    template <class INIT_LIST_TYPE, class ARGS_01,
+                                    class ARGS_02>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02));
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 2
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 3
-    template<class IL_TYPE, class ARGS_01,
-                            class ARGS_02,
-                            class ARGS_03>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+    template <class INIT_LIST_TYPE, class ARGS_01,
+                                    class ARGS_02,
+                                    class ARGS_03>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03));
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 3
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 4
-    template<class IL_TYPE, class ARGS_01,
-                            class ARGS_02,
-                            class ARGS_03,
-                            class ARGS_04>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+    template <class INIT_LIST_TYPE, class ARGS_01,
+                                    class ARGS_02,
+                                    class ARGS_03,
+                                    class ARGS_04>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -533,13 +531,13 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 4
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 5
-    template<class IL_TYPE, class ARGS_01,
-                            class ARGS_02,
-                            class ARGS_03,
-                            class ARGS_04,
-                            class ARGS_05>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+    template <class INIT_LIST_TYPE, class ARGS_01,
+                                    class ARGS_02,
+                                    class ARGS_03,
+                                    class ARGS_04,
+                                    class ARGS_05>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -548,14 +546,14 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 5
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 6
-    template<class IL_TYPE, class ARGS_01,
-                            class ARGS_02,
-                            class ARGS_03,
-                            class ARGS_04,
-                            class ARGS_05,
-                            class ARGS_06>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+    template <class INIT_LIST_TYPE, class ARGS_01,
+                                    class ARGS_02,
+                                    class ARGS_03,
+                                    class ARGS_04,
+                                    class ARGS_05,
+                                    class ARGS_06>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -565,15 +563,15 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 6
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 7
-    template<class IL_TYPE, class ARGS_01,
-                            class ARGS_02,
-                            class ARGS_03,
-                            class ARGS_04,
-                            class ARGS_05,
-                            class ARGS_06,
-                            class ARGS_07>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+    template <class INIT_LIST_TYPE, class ARGS_01,
+                                    class ARGS_02,
+                                    class ARGS_03,
+                                    class ARGS_04,
+                                    class ARGS_05,
+                                    class ARGS_06,
+                                    class ARGS_07>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -584,16 +582,16 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 7
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 8
-    template<class IL_TYPE, class ARGS_01,
-                            class ARGS_02,
-                            class ARGS_03,
-                            class ARGS_04,
-                            class ARGS_05,
-                            class ARGS_06,
-                            class ARGS_07,
-                            class ARGS_08>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+    template <class INIT_LIST_TYPE, class ARGS_01,
+                                    class ARGS_02,
+                                    class ARGS_03,
+                                    class ARGS_04,
+                                    class ARGS_05,
+                                    class ARGS_06,
+                                    class ARGS_07,
+                                    class ARGS_08>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -605,17 +603,17 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 8
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 9
-    template<class IL_TYPE, class ARGS_01,
-                            class ARGS_02,
-                            class ARGS_03,
-                            class ARGS_04,
-                            class ARGS_05,
-                            class ARGS_06,
-                            class ARGS_07,
-                            class ARGS_08,
-                            class ARGS_09>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+    template <class INIT_LIST_TYPE, class ARGS_01,
+                                    class ARGS_02,
+                                    class ARGS_03,
+                                    class ARGS_04,
+                                    class ARGS_05,
+                                    class ARGS_06,
+                                    class ARGS_07,
+                                    class ARGS_08,
+                                    class ARGS_09>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -628,18 +626,18 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 9
 
 #if BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 10
-    template<class IL_TYPE, class ARGS_01,
-                            class ARGS_02,
-                            class ARGS_03,
-                            class ARGS_04,
-                            class ARGS_05,
-                            class ARGS_06,
-                            class ARGS_07,
-                            class ARGS_08,
-                            class ARGS_09,
-                            class ARGS_10>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+    template <class INIT_LIST_TYPE, class ARGS_01,
+                                    class ARGS_02,
+                                    class ARGS_03,
+                                    class ARGS_04,
+                                    class ARGS_05,
+                                    class ARGS_06,
+                                    class ARGS_07,
+                                    class ARGS_08,
+                                    class ARGS_09,
+                                    class ARGS_10>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02),
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03),
@@ -653,21 +651,21 @@ struct Optional_DataImp {
 #endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_A >= 10
 
 
-    #endif
+#endif
 #else
 // The generated code below is a workaround for the absence of perfect
 // forwarding in some compilers.
-    template<class... ARGS>
-    void emplace(bslma::Allocator *allocator,
+    template <class... ARGS>
+    void emplace(bslma::Allocator                           *allocator,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)...);
 
-    #if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
-    template<class IL_TYPE, class... ARGS>
-    void emplace(bslma::Allocator              *allocator,
-                 std::initializer_list<IL_TYPE> initializer_list,
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
+    template <class INIT_LIST_TYPE, class... ARGS>
+    void emplace(bslma::Allocator                           *allocator,
+                 std::initializer_list<INIT_LIST_TYPE>       initializer_list,
                  BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)...);
 
-    #endif
+#endif
 // }}} END GENERATED CODE
 #endif
 
@@ -677,14 +675,14 @@ struct Optional_DataImp {
     TYPE& value() BSLS_KEYWORD_LVREF_QUAL;
         // Return the 'value_type' object in 'd_buffer' with const
         // qualification adjusted to match that of 'TYPE'.  The behavior is
-        // undefined unless 'this->hasValue() == true'
+        // undefined unless 'true == hasValue()'
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
     TYPE&& value() BSLS_KEYWORD_RVREF_QUAL;
         // Return the 'value_type' object in 'd_buffer' with const
         // qualification adjusted to match that of 'TYPE'.  The behavior is
         // undefined unless 'this->hasValue() == true'
-#endif // BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS
+#endif  // BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS
 
     //ACCESSORS
     bool hasValue() const BSLS_KEYWORD_NOEXCEPT;
@@ -701,852 +699,17 @@ struct Optional_DataImp {
         // Return the 'value_type' object in 'd_buffer' with const
         // qualification adjusted to match that of 'TYPE'.  The behavior is
         // undefined unless 'this->hasValue() == true'
-#endif // BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS
-
+#endif  // BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS
 };
 
-template <class TYPE>
-Optional_DataImp<TYPE>::Optional_DataImp()
-BSLS_KEYWORD_NOEXCEPT
-: d_hasValue(false)
-{}
+                            // ===================
+                            // class Optional_Data
+                            // ===================
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
-template <class TYPE>
-template <class... ARGS>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...
-                                  );
-    d_hasValue = true;
-}
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
-template <class TYPE>
-template<class IL_TYPE, class... ARGS>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                                  BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...
-                                  );
-    d_hasValue = true;
-}
-#endif//BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS
-#elif BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
-// {{{ BEGIN GENERATED CODE
-// The following section is automatically generated.  **DO NOT EDIT**
-// Generator command line: sim_cpp11_features.pl bslstl_optional.h
-#ifndef BSLSTL_OPTIONAL_VARIADIC_LIMIT
-#define BSLSTL_OPTIONAL_VARIADIC_LIMIT 10
-#endif
-#ifndef BSLSTL_OPTIONAL_VARIADIC_LIMIT_B
-#define BSLSTL_OPTIONAL_VARIADIC_LIMIT_B BSLSTL_OPTIONAL_VARIADIC_LIMIT
-#endif
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 0
-template <class TYPE>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 0
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 1
-template <class TYPE>
-template <class ARGS_01>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 1
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 2
-template <class TYPE>
-template <class ARGS_01,
-          class ARGS_02>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 2
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 3
-template <class TYPE>
-template <class ARGS_01,
-          class ARGS_02,
-          class ARGS_03>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 3
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 4
-template <class TYPE>
-template <class ARGS_01,
-          class ARGS_02,
-          class ARGS_03,
-          class ARGS_04>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 4
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 5
-template <class TYPE>
-template <class ARGS_01,
-          class ARGS_02,
-          class ARGS_03,
-          class ARGS_04,
-          class ARGS_05>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 5
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 6
-template <class TYPE>
-template <class ARGS_01,
-          class ARGS_02,
-          class ARGS_03,
-          class ARGS_04,
-          class ARGS_05,
-          class ARGS_06>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 6
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 7
-template <class TYPE>
-template <class ARGS_01,
-          class ARGS_02,
-          class ARGS_03,
-          class ARGS_04,
-          class ARGS_05,
-          class ARGS_06,
-          class ARGS_07>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 7
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 8
-template <class TYPE>
-template <class ARGS_01,
-          class ARGS_02,
-          class ARGS_03,
-          class ARGS_04,
-          class ARGS_05,
-          class ARGS_06,
-          class ARGS_07,
-          class ARGS_08>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 8
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 9
-template <class TYPE>
-template <class ARGS_01,
-          class ARGS_02,
-          class ARGS_03,
-          class ARGS_04,
-          class ARGS_05,
-          class ARGS_06,
-          class ARGS_07,
-          class ARGS_08,
-          class ARGS_09>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_09) args_09)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_09, args_09)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 9
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 10
-template <class TYPE>
-template <class ARGS_01,
-          class ARGS_02,
-          class ARGS_03,
-          class ARGS_04,
-          class ARGS_05,
-          class ARGS_06,
-          class ARGS_07,
-          class ARGS_08,
-          class ARGS_09,
-          class ARGS_10>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_09) args_09,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_10) args_10)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_09, args_09),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_10, args_10)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 10
-
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 0
-template <class TYPE>
-template<class IL_TYPE>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 0
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 1
-template <class TYPE>
-template<class IL_TYPE, class ARGS_01>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                                BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 1
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 2
-template <class TYPE>
-template<class IL_TYPE, class ARGS_01,
-                        class ARGS_02>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 2
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 3
-template <class TYPE>
-template<class IL_TYPE, class ARGS_01,
-                        class ARGS_02,
-                        class ARGS_03>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 3
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 4
-template <class TYPE>
-template<class IL_TYPE, class ARGS_01,
-                        class ARGS_02,
-                        class ARGS_03,
-                        class ARGS_04>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 4
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 5
-template <class TYPE>
-template<class IL_TYPE, class ARGS_01,
-                        class ARGS_02,
-                        class ARGS_03,
-                        class ARGS_04,
-                        class ARGS_05>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 5
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 6
-template <class TYPE>
-template<class IL_TYPE, class ARGS_01,
-                        class ARGS_02,
-                        class ARGS_03,
-                        class ARGS_04,
-                        class ARGS_05,
-                        class ARGS_06>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 6
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 7
-template <class TYPE>
-template<class IL_TYPE, class ARGS_01,
-                        class ARGS_02,
-                        class ARGS_03,
-                        class ARGS_04,
-                        class ARGS_05,
-                        class ARGS_06,
-                        class ARGS_07>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 7
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 8
-template <class TYPE>
-template<class IL_TYPE, class ARGS_01,
-                        class ARGS_02,
-                        class ARGS_03,
-                        class ARGS_04,
-                        class ARGS_05,
-                        class ARGS_06,
-                        class ARGS_07,
-                        class ARGS_08>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 8
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 9
-template <class TYPE>
-template<class IL_TYPE, class ARGS_01,
-                        class ARGS_02,
-                        class ARGS_03,
-                        class ARGS_04,
-                        class ARGS_05,
-                        class ARGS_06,
-                        class ARGS_07,
-                        class ARGS_08,
-                        class ARGS_09>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_09) args_09)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_09, args_09)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 9
-
-#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 10
-template <class TYPE>
-template<class IL_TYPE, class ARGS_01,
-                        class ARGS_02,
-                        class ARGS_03,
-                        class ARGS_04,
-                        class ARGS_05,
-                        class ARGS_06,
-                        class ARGS_07,
-                        class ARGS_08,
-                        class ARGS_09,
-                        class ARGS_10>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_09) args_09,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_10) args_10)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_09, args_09),
-                               BSLS_COMPILERFEATURES_FORWARD(ARGS_10, args_10)
-                                  );
-    d_hasValue = true;
-}
-#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 10
-
-#endif
-#else
-// The generated code below is a workaround for the absence of perfect
-// forwarding in some compilers.
-template <class TYPE>
-template <class... ARGS>
-inline
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...
-                                  );
-    d_hasValue = true;
-}
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
-template <class TYPE>
-template<class IL_TYPE, class... ARGS>
-void Optional_DataImp<TYPE>::emplace(
-                          bslma::Allocator                          *allocator,
-                          std::initializer_list<IL_TYPE>             il,
-                          BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
-{
-    reset();
-    BloombergLP::bslma::ConstructionUtil::construct(
-                                  d_buffer.address(),
-                                  allocator,
-                                  il,
-                                  BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...
-                                  );
-    d_hasValue = true;
-}
-#endif
-// }}} END GENERATED CODE
-#endif
-
-template <class TYPE>
-void Optional_DataImp<TYPE>::reset()
-BSLS_KEYWORD_NOEXCEPT
-{
-    if (d_hasValue) {
-        BloombergLP::bslma::DestructionUtil::destroy(&(d_buffer.object()));
-    }
-    d_hasValue = false;
-}
-
-//ACCESSORS
-template <class TYPE>
-inline
-bool
-Optional_DataImp<TYPE>::hasValue()
-    const BSLS_KEYWORD_NOEXCEPT
-{
-    if (d_hasValue) {
-        return true;                                                  // RETURN
-    }
-    return false;
-}
-
-template <class TYPE>
-inline
-TYPE&
-Optional_DataImp<TYPE>::value()
-    BSLS_KEYWORD_LVREF_QUAL
-{
-    BSLS_ASSERT(d_hasValue);
-
-    return d_buffer.object();
-}
-
-template <class TYPE>
-inline
-const TYPE&
-Optional_DataImp<TYPE>::value()
-    const BSLS_KEYWORD_LVREF_QUAL
-{
-    BSLS_ASSERT(d_hasValue);
-
-    return d_buffer.object();
-}
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
-template <class TYPE>
-inline
-TYPE&&
-Optional_DataImp<TYPE>::value()
-    BSLS_KEYWORD_RVREF_QUAL
-{
-    BSLS_ASSERT(d_hasValue);
-
-    return std::move(d_buffer.object());
-}
-
-template <class TYPE>
-inline
-const TYPE&&
-Optional_DataImp<TYPE>::value()
-    const BSLS_KEYWORD_RVREF_QUAL
-{
-    BSLS_ASSERT(d_hasValue);
-
-    return std::move(d_buffer.object());
-}
-#endif //defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
-
-                        // ===================
-                        // class Optional_Data
-                        // ===================
-
-template <class TYPE, bool IS_TRIVIALLY_DESTRUCTIBLE =
-                        BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE<TYPE>::value>
-struct Optional_Data : public Optional_DataImp<TYPE>{
+template <class TYPE,
+          bool IS_TRIVIALLY_DESTRUCTIBLE =
+              BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE<TYPE>::value>
+struct Optional_Data : public Optional_DataImp<TYPE> {
     // Component-level class; DO NOT USE
 
     // Optional_Data is a type used to manage 'value_type' object in
@@ -1571,12 +734,11 @@ struct Optional_Data : public Optional_DataImp<TYPE>{
     // CREATORS
     ~Optional_Data();
         // Destroy the managed 'value_type' object, if it exists.
-
 };
 
-                        // ===================
-                        // class Optional_Data
-                        // ===================
+                            // ===================
+                            // class Optional_Data
+                            // ===================
 
 template <class TYPE>
 struct Optional_Data<TYPE, true> : public Optional_DataImp<TYPE> {
@@ -1602,22 +764,830 @@ struct Optional_Data<TYPE, true> : public Optional_DataImp<TYPE> {
     // 'is_trivially_destructible' itself.
 
   public:
-
 #ifndef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
-    // workaround for C++03 bsl::is_trivially_copyable trait.  Note that,
+    // Workaround for C++03 'bsl::is_trivially_copyable' trait.  Note that,
     // whether 'Optional_Data<TYPE>' satisfies 'bsl::is_trivally_copyable'
     // doesn't affect 'Optional<TYPE>' 'bsl::is_trivally_copyable' trait.  We
     // only add this nested trait for the tests to be able to check the C++03
     // implementation of 'Optional_Data'.  For correct C++03 functionality,
     // 'bsl::optional' has to add a nested trait as well.
     BSLMF_NESTED_TRAIT_DECLARATION_IF(Optional_Data,
-                           bsl::is_trivially_copyable,
-                           bsl::is_trivially_copyable<TYPE>::value);
-#endif //BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
-
+                                      bsl::is_trivially_copyable,
+                                      bsl::is_trivially_copyable<TYPE>::value);
+#endif  //BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
 };
 
+// ============================================================================
+//                           INLINE DEFINITIONS
+// ============================================================================
 
+                           // ======================
+                           // class Optional_DataImp
+                           // ======================
+
+// CREATORS
+template <class TYPE>
+Optional_DataImp<TYPE>::Optional_DataImp() BSLS_KEYWORD_NOEXCEPT
+: d_hasValue(false)
+{
+}
+
+// MANIPULATORS
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+template <class TYPE>
+template <class... ARGS>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)...  args)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...);
+    d_hasValue = true;
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
+template <class TYPE>
+template <class INIT_LIST_TYPE, class... ARGS>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)...  args)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...);
+    d_hasValue = true;
+}
+#endif  //BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS
+#elif BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
+// {{{ BEGIN GENERATED CODE
+// The following section is automatically generated.  **DO NOT EDIT**
+// Generator command line: sim_cpp11_features.pl bslstl_optional.h
+#ifndef BSLSTL_OPTIONAL_VARIADIC_LIMIT
+#define BSLSTL_OPTIONAL_VARIADIC_LIMIT 10
+#endif
+#ifndef BSLSTL_OPTIONAL_VARIADIC_LIMIT_B
+#define BSLSTL_OPTIONAL_VARIADIC_LIMIT_B BSLSTL_OPTIONAL_VARIADIC_LIMIT
+#endif
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 0
+template <class TYPE>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator);
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 0
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 1
+template <class TYPE>
+template <class ARGS_01>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 1
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 2
+template <class TYPE>
+template <class ARGS_01,
+          class ARGS_02>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 2
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 3
+template <class TYPE>
+template <class ARGS_01,
+          class ARGS_02,
+          class ARGS_03>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 3
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 4
+template <class TYPE>
+template <class ARGS_01,
+          class ARGS_02,
+          class ARGS_03,
+          class ARGS_04>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 4
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 5
+template <class TYPE>
+template <class ARGS_01,
+          class ARGS_02,
+          class ARGS_03,
+          class ARGS_04,
+          class ARGS_05>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 5
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 6
+template <class TYPE>
+template <class ARGS_01,
+          class ARGS_02,
+          class ARGS_03,
+          class ARGS_04,
+          class ARGS_05,
+          class ARGS_06>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 6
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 7
+template <class TYPE>
+template <class ARGS_01,
+          class ARGS_02,
+          class ARGS_03,
+          class ARGS_04,
+          class ARGS_05,
+          class ARGS_06,
+          class ARGS_07>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 7
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 8
+template <class TYPE>
+template <class ARGS_01,
+          class ARGS_02,
+          class ARGS_03,
+          class ARGS_04,
+          class ARGS_05,
+          class ARGS_06,
+          class ARGS_07,
+          class ARGS_08>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 8
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 9
+template <class TYPE>
+template <class ARGS_01,
+          class ARGS_02,
+          class ARGS_03,
+          class ARGS_04,
+          class ARGS_05,
+          class ARGS_06,
+          class ARGS_07,
+          class ARGS_08,
+          class ARGS_09>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_09) args_09)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_09, args_09));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 9
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 10
+template <class TYPE>
+template <class ARGS_01,
+          class ARGS_02,
+          class ARGS_03,
+          class ARGS_04,
+          class ARGS_05,
+          class ARGS_06,
+          class ARGS_07,
+          class ARGS_08,
+          class ARGS_09,
+          class ARGS_10>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_09) args_09,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_10) args_10)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_09, args_09),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_10, args_10));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 10
+
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 0
+template <class TYPE>
+template <class INIT_LIST_TYPE>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il);
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 0
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 1
+template <class TYPE>
+template <class INIT_LIST_TYPE, class ARGS_01>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 1
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 2
+template <class TYPE>
+template <class INIT_LIST_TYPE, class ARGS_01,
+                                class ARGS_02>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 2
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 3
+template <class TYPE>
+template <class INIT_LIST_TYPE, class ARGS_01,
+                                class ARGS_02,
+                                class ARGS_03>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 3
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 4
+template <class TYPE>
+template <class INIT_LIST_TYPE, class ARGS_01,
+                                class ARGS_02,
+                                class ARGS_03,
+                                class ARGS_04>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 4
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 5
+template <class TYPE>
+template <class INIT_LIST_TYPE, class ARGS_01,
+                                class ARGS_02,
+                                class ARGS_03,
+                                class ARGS_04,
+                                class ARGS_05>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 5
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 6
+template <class TYPE>
+template <class INIT_LIST_TYPE, class ARGS_01,
+                                class ARGS_02,
+                                class ARGS_03,
+                                class ARGS_04,
+                                class ARGS_05,
+                                class ARGS_06>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 6
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 7
+template <class TYPE>
+template <class INIT_LIST_TYPE, class ARGS_01,
+                                class ARGS_02,
+                                class ARGS_03,
+                                class ARGS_04,
+                                class ARGS_05,
+                                class ARGS_06,
+                                class ARGS_07>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 7
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 8
+template <class TYPE>
+template <class INIT_LIST_TYPE, class ARGS_01,
+                                class ARGS_02,
+                                class ARGS_03,
+                                class ARGS_04,
+                                class ARGS_05,
+                                class ARGS_06,
+                                class ARGS_07,
+                                class ARGS_08>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 8
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 9
+template <class TYPE>
+template <class INIT_LIST_TYPE, class ARGS_01,
+                                class ARGS_02,
+                                class ARGS_03,
+                                class ARGS_04,
+                                class ARGS_05,
+                                class ARGS_06,
+                                class ARGS_07,
+                                class ARGS_08,
+                                class ARGS_09>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_09) args_09)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_09, args_09));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 9
+
+#if BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 10
+template <class TYPE>
+template <class INIT_LIST_TYPE, class ARGS_01,
+                                class ARGS_02,
+                                class ARGS_03,
+                                class ARGS_04,
+                                class ARGS_05,
+                                class ARGS_06,
+                                class ARGS_07,
+                                class ARGS_08,
+                                class ARGS_09,
+                                class ARGS_10>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_01) args_01,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_02) args_02,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_03) args_03,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_04) args_04,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_05) args_05,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_06) args_06,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_07) args_07,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_08) args_08,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_09) args_09,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_10) args_10)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_01, args_01),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_02, args_02),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_03, args_03),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_04, args_04),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_05, args_05),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_06, args_06),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_07, args_07),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_08, args_08),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_09, args_09),
+        BSLS_COMPILERFEATURES_FORWARD(ARGS_10, args_10));
+    d_hasValue = true;
+}
+#endif  // BSLSTL_OPTIONAL_VARIADIC_LIMIT_B >= 10
+
+#endif
+#else
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
+template <class TYPE>
+template <class... ARGS>
+inline
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)...  args)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...);
+    d_hasValue = true;
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS)
+template <class TYPE>
+template <class INIT_LIST_TYPE, class... ARGS>
+void Optional_DataImp<TYPE>::emplace(
+                         bslma::Allocator                           *allocator,
+                         std::initializer_list<INIT_LIST_TYPE>       il,
+                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)...  args)
+{
+    reset();
+    BloombergLP::bslma::ConstructionUtil::construct(
+        d_buffer.address(),
+        allocator,
+        il,
+        BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...);
+    d_hasValue = true;
+}
+#endif
+// }}} END GENERATED CODE
+#endif
+
+template <class TYPE>
+void Optional_DataImp<TYPE>::reset() BSLS_KEYWORD_NOEXCEPT
+{
+    if (d_hasValue) {
+        bslma::DestructionUtil::destroy(&(d_buffer.object()));
+    }
+    d_hasValue = false;
+}
+
+template <class TYPE>
+inline
+TYPE& Optional_DataImp<TYPE>::value() BSLS_KEYWORD_LVREF_QUAL
+{
+    BSLS_ASSERT(d_hasValue);
+
+    return d_buffer.object();
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
+template <class TYPE>
+inline
+TYPE&& Optional_DataImp<TYPE>::value() BSLS_KEYWORD_RVREF_QUAL
+{
+    BSLS_ASSERT(d_hasValue);
+
+    return std::move(d_buffer.object());
+}
+#endif  //defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
+
+//ACCESSORS
+template <class TYPE>
+inline
+bool Optional_DataImp<TYPE>::hasValue() const BSLS_KEYWORD_NOEXCEPT
+{
+    return d_hasValue;
+}
+
+template <class TYPE>
+inline
+const TYPE& Optional_DataImp<TYPE>::value() const BSLS_KEYWORD_LVREF_QUAL
+{
+    BSLS_ASSERT(d_hasValue);
+
+    return d_buffer.object();
+}
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
+template <class TYPE>
+inline
+const TYPE&& Optional_DataImp<TYPE>::value() const BSLS_KEYWORD_RVREF_QUAL
+{
+    BSLS_ASSERT(d_hasValue);
+
+    return std::move(d_buffer.object());
+}
+#endif  //defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
+
+                            // ===================
+                            // class Optional_Data
+                            // ===================
+
+// CREATORS
 template <class TYPE, bool IS_TRIVIALLY_DESTRUCTIBLE>
 Optional_Data<TYPE, IS_TRIVIALLY_DESTRUCTIBLE>::~Optional_Data()
 {
@@ -1634,8 +1604,7 @@ Optional_Data<TYPE, IS_TRIVIALLY_DESTRUCTIBLE>::~Optional_Data()
 
 #undef BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE
 
-
-#endif // INCLUDED_BSLSTL_OPTIONAL
+#endif  // INCLUDED_BSLSTL_OPTIONAL
 // ----------------------------------------------------------------------------
 // Copyright 2020 Bloomberg Finance L.P.
 //

--- a/groups/bsl/bslstl/bslstl_optional.h
+++ b/groups/bsl/bslstl/bslstl_optional.h
@@ -712,25 +712,24 @@ template <class TYPE,
           bool IS_TRIVIALLY_DESTRUCTIBLE =
               BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE<TYPE>::value>
 struct Optional_Data : public Optional_DataImp<TYPE> {
-    // Component-level class; DO NOT USE
-
-    // Optional_Data is a type used to manage 'value_type' object in
+    // This component-private 'struct' manages a 'value_type' object in
     // 'optional'.  It allows 'optional<TYPE>' to be trivially destructible if
     // 'TYPE' is trivially destructible.  This class also provides an
-    // abstraction for const value type.  An 'optional' may contain a 'const'
+    // abstraction for 'const' value type.  An 'optional' may contain a 'const'
     // type object.  An assignment to such an 'optional' should not succeed.
     // However, unless the 'optional' itself is 'const', it should be possible
     // to change the value of the 'optional' using 'emplace'.  In order to
     // allow for that, this class manages a non-const object of 'value_type',
     // but all the observers return a 'const' adjusted reference to the managed
     // object.  This functionality is common for all value types and is
-    // implemented in the Optional_DataImp base class.  The derived class,
+    // implemented in the 'Optional_DataImp' base class.  The derived class,
     // 'Optional_Data', is specialised on 'value_type'
-    // 'is_trivially_destructible' trait.  The main template is for non
-    // trivially destructible types, and it provides a destructor that ensures
-    // the value_type destructor is called if 'd_buffer' holds an object.  The
-    // specialisation for 'is_trivially_destructible' types does not have a
-    // user provided destructor and 'is_trivially_destructible' itself.
+    // 'is_trivially_destructible' trait.  The main template is for types that
+    // are not trivially destructible, and it provides a destructor that
+    // ensures the 'value_type' destructor is called if 'd_buffer' holds an
+    // object.  The specialisation for 'is_trivially_destructible' types does
+    // not have a user-provided destructor and 'is_trivially_destructible'
+    // itself.
 
   public:
     // CREATORS
@@ -744,25 +743,23 @@ struct Optional_Data : public Optional_DataImp<TYPE> {
 
 template <class TYPE>
 struct Optional_Data<TYPE, true> : public Optional_DataImp<TYPE> {
-    // Component-level class; DO NOT USE
-
-    // Optional_Data is a type used to manage 'value_type' object in
+    // This component-private 'struct' manages a 'value_type' object in
     // 'optional'.  It allows 'optional<TYPE>' to be trivially destructible if
     // 'TYPE' is trivially destructible.  This class also provides an
-    // abstraction for const value type.  An 'optional' may contain a 'const'
+    // abstraction for 'const' value type.  An 'optional' may contain a 'const'
     // type object.  An assignment to such an 'optional' should not succeed.
     // However, unless the 'optional' itself is 'const', it should be possible
     // to change the value of the 'optional' using 'emplace'.  In order to
     // allow for that, this class manages a non-const object of 'value_type',
     // but all the observers return a 'const' adjusted reference to the managed
     // object.  This functionality is common for all value types and is
-    // implemented in the Optional_DataImp base class.  The derived class,
+    // implemented in the 'Optional_DataImp' base class.  The derived class,
     // 'Optional_Data', is specialised on 'value_type'
-    // 'is_trivially_destructible' trait.  The main template is for non
-    // trivially destructible types, and it provides a destructor that ensures
-    // the value_type destructor is called if 'd_buffer' holds an object.  This
-    // specialisation is for 'is_trivially_destructible' types, and does not
-    // have a user provided destructor, which makes it
+    // 'is_trivially_destructible' trait.  The main template is for types that
+    // are not trivially destructible, and it provides a destructor that
+    // ensures the 'value_type' destructor is called if 'd_buffer' holds an
+    // object.  This specialisation is for 'is_trivially_destructible' types,
+    // and does not have a user provided destructor, which makes it
     // 'is_trivially_destructible' itself.
 
   public:

--- a/groups/bsl/bslstl/bslstl_optional.h
+++ b/groups/bsl/bslstl/bslstl_optional.h
@@ -152,12 +152,11 @@ struct nullopt_t {
 };
 
 // CREATORS
-
-// bde_verify requires an out-of-class definition.  The 'constexpr' variable
-// requires a constructor definition before its own definition.
 inline
 BSLS_KEYWORD_CONSTEXPR nullopt_t::nullopt_t(int) BSLS_KEYWORD_NOEXCEPT
 {
+    // This 'constexpr' function has to be defined before initialializing the
+    // 'constexpr' value, 'nullopt', below.
 }
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_CONSTEXPR)
@@ -185,10 +184,10 @@ namespace bslstl {
                         // ============================
 
 struct Optional_OptNoSuchType {
-    // This component-private trivial tag type is used to distinguish between arguments passed by
-    // a user, and an 'enable_if' argument.  It is not default constructible so
-    // the following construction never invokes a constrained single parameter
-    // constructor:
+    // This component-private trivial tag type is used to distinguish between
+    // arguments passed by a user, and an 'enable_if' argument.  It is not
+    // default constructible so the following construction never invokes a
+    // constrained single parameter constructor:
     //..
     //   optional<SomeType> o(int, {});
     //..
@@ -201,13 +200,12 @@ struct Optional_OptNoSuchType {
 };
 
 // CREATORS
-
-// bde_verify requires an out-of-class definition.  The 'constexpr' variable
-// requires a constructor definition before its own definition.
 inline
 BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType::Optional_OptNoSuchType(
                                                      int) BSLS_KEYWORD_NOEXCEPT
 {
+    // This 'constexpr' function has to be defined before initialializing the
+    // 'constexpr' value, 'optNoSuchType', below.
 }
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_CONSTEXPR)
@@ -695,15 +693,15 @@ struct Optional_Data<TYPE, true> : public Optional_DataImp<TYPE> {
 
   public:
 #ifndef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
-    // Workaround for C++03 'bsl::is_trivially_copyable' trait.  Note that,
-    // whether 'Optional_Data<TYPE>' satisfies 'bsl::is_trivally_copyable'
-    // doesn't affect 'Optional<TYPE>' 'bsl::is_trivally_copyable' trait.  We
-    // only add this nested trait for the tests to be able to check the C++03
-    // implementation of 'Optional_Data'.  For correct C++03 functionality,
-    // 'bsl::optional' has to add a nested trait as well.
     BSLMF_NESTED_TRAIT_DECLARATION_IF(Optional_Data,
                                       bsl::is_trivially_copyable,
                                       bsl::is_trivially_copyable<TYPE>::value);
+        // Workaround for C++03 'bsl::is_trivially_copyable' trait.  Note that,
+        // whether 'Optional_Data<TYPE>' satisfies 'bsl::is_trivally_copyable'
+        // doesn't affect 'Optional<TYPE>' 'bsl::is_trivally_copyable' trait.
+        // We only add this nested trait for the tests to be able to check the
+        // C++03 implementation of 'Optional_Data'.  For correct C++03
+        // functionality, 'bsl::optional' has to add a nested trait as well.
 #endif  //BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
 };
 
@@ -1540,7 +1538,7 @@ const TYPE& Optional_DataImp<TYPE>::value() const
 template <class TYPE, bool IS_TRIVIALLY_DESTRUCTIBLE>
 Optional_Data<TYPE, IS_TRIVIALLY_DESTRUCTIBLE>::~Optional_Data()
 {
-    reset();
+    this->reset();
 }
 
 }  // close package namespace

--- a/groups/bsl/bslstl/bslstl_optional.h
+++ b/groups/bsl/bslstl/bslstl_optional.h
@@ -81,9 +81,10 @@ BSLS_IDENT("$Id: $")
 //:   C++03 will not work.
 
 #include <bslscm_version.h>
+#include <bslstl_inplace.h>
 
-#include <bslstl_badoptionalaccess.h>
 #include <bslalg_swaputil.h>
+#include <bslstl_badoptionalaccess.h>
 
 #include <bslma_constructionutil.h>
 #include <bslma_default.h>
@@ -110,7 +111,6 @@ BSLS_IDENT("$Id: $")
 #include <bsls_util.h>
 
 #include <stddef.h>
-#include "bslstl_inplace.h"
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
 #include <type_traits>
@@ -197,8 +197,8 @@ struct Optional_OptNoSuchType {
     // CREATORS
     explicit BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType(
                                                     int) BSLS_KEYWORD_NOEXCEPT;
-        // Create an 'Optional_OptNoSuchType' object.  Note that the argument is
-        // not used.
+        // Create an 'Optional_OptNoSuchType' object.  Note that the argument
+        // is not used.
 };
 
 // CREATORS
@@ -211,7 +211,6 @@ BSLS_KEYWORD_CONSTEXPR Optional_OptNoSuchType::Optional_OptNoSuchType(
                                                      int) BSLS_KEYWORD_NOEXCEPT
 {
 }
-
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_CONSTEXPR)
 BSLS_KEYWORD_INLINE_CONSTEXPR Optional_OptNoSuchType optNoSuchType =
@@ -240,22 +239,13 @@ extern const Optional_OptNoSuchType optNoSuchType;
 template <class TYPE>
 struct Optional_DataImp {
     // This component-private 'struct' manages a 'value_type' object in
-    // 'optional'.  This class provides an
-    // abstraction for 'const' value type.  An 'optional' may contain a 'const'
-    // type object.  An assignment to such an 'optional' should not succeed.
-    // However, unless the 'optional' itself is 'const', it should be possible
-    // to change the value of the 'optional' using 'emplace'.  In order to
-    // allow for that, this class manages a non-const object of 'value_type',
-    // but all the accessors return a 'const' adjusted reference to the managed
-    // object.  This functionality is common for all value types and is
-    // implemented in the 'Optional_DataImp' base class.  The derived class,
-    // 'Optional_Data', is specialised on 'value_type'
-    // 'is_trivially_destructible' trait.  The main template is for types that
-    // are not trivially destructible, and it provides a destructor that
-    // ensures the 'value_type' destructor is called if 'd_buffer' holds an
-    // object.  The specialisation for 'is_trivially_destructible' types does
-    // not have a user-provided destructor and 'is_trivially_destructible'
-    // itself.
+    // 'optional'.  This class provides an abstraction for 'const' value type.
+    // An 'optional' may contain a 'const' type object.  An assignment to such
+    // an 'optional' should not succeed.  However, unless the 'optional' itself
+    // is 'const', it should be possible to change the value of the 'optional'
+    // using 'emplace'.  In order to allow for that, this class manages a
+    // non-const object of 'value_type', but all the accessors return a 'const'
+    // adjusted reference to the managed object.
 
   private:
     // PRIVATE TYPES
@@ -264,8 +254,8 @@ struct Optional_DataImp {
     // DATA
     bsls::ObjectBuffer<StoredType> d_buffer;
         // in-place 'TYPE' object
-        
-    bool                           d_hasValue;  
+
+    bool                           d_hasValue;
         // 'true' if object has a value, and 'false' otherwise
   public:
     // CREATORS
@@ -644,7 +634,7 @@ struct Optional_DataImp {
         // Destroy the 'value_type' object in 'd_buffer', if any.
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
-    TYPE& value() &;
+    TYPE&  value() &;
     TYPE&& value() &&;
         // Return the 'value_type' object in 'd_buffer' with const
         // qualification adjusted to match that of 'TYPE'.  The behavior is
@@ -662,11 +652,11 @@ struct Optional_DataImp {
         //otherwise.
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_REF_QUALIFIERS)
-    const TYPE& value() const &;
+    const TYPE&  value() const &;
     const TYPE&& value() const &&;
-        // Return the 'value_type' object in 'd_buffer' with const
-        // qualification adjusted to match that of 'TYPE'.  The behavior is
-        // undefined unless 'this->hasValue() == true'
+        // Return the 'value_type' object in 'd_buffer' with const qualification
+        // adjusted to match that of 'TYPE'.  The behavior is undefined unless
+        // 'this->hasValue() == true'.
 
 #else
     const TYPE& value() const;
@@ -685,8 +675,9 @@ template <class TYPE,
               BSLSTL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE<TYPE>::value>
 struct Optional_Data : public Optional_DataImp<TYPE> {
     // This component-private 'struct' manages a 'value_type' object in
-    // 'optional' by inheriting from `Optional_DataImp`.  In addition, this primary template properly
-    // destroys the owned instance of 'TYPE' in its destructor.
+    // 'optional' by inheriting from `Optional_DataImp`.  In addition, this
+    // primary template properly destroys the owned instance of 'TYPE' in its
+    // destructor.
 
   public:
     // CREATORS
@@ -700,9 +691,9 @@ struct Optional_Data : public Optional_DataImp<TYPE> {
 
 template <class TYPE>
 struct Optional_Data<TYPE, true> : public Optional_DataImp<TYPE> {
-    // This partial specialization manages a trivially destructible 'value_type' in optional. 
-    // It does not have a user-provided destructor, which makes it
-    // 'is_trivially_destructible' itself.
+    // This partial specialization manages a trivially destructible
+    // 'value_type' in optional.  It does not have a user-provided destructor,
+    // which makes it 'is_trivially_destructible' itself.
 
   public:
 #ifndef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY

--- a/groups/bsl/bslstl/bslstl_optional.t.cpp
+++ b/groups/bsl/bslstl/bslstl_optional.t.cpp
@@ -860,7 +860,6 @@ class TestDriver {
     // type.
   public:
     static void testCase2();
-    static void testCase2_Imp();
         // Optional_DataImp TEST.  The test requires TYPE to be default
         // constructible.
 
@@ -869,14 +868,7 @@ class TestDriver {
 
 };
 template <class TYPE>
-void TestDriver<TYPE>::testCase2()
-{
-    testCase2_Imp();
-    TestDriver<const TYPE>::testCase2_Imp();
-
-}
-template <class TYPE>
-void TestDriver<TYPE>::testCase2_Imp()
+void testCase2_Imp()
 {
     // --------------------------------------------------------------------
     // 'Optional_DataImp' TEST
@@ -923,6 +915,13 @@ void TestDriver<TYPE>::testCase2_Imp()
 
     X.reset();
     ASSERT(!X.hasValue());
+
+}
+template <class TYPE>
+void TestDriver<TYPE>::testCase2()
+{
+    testCase2_Imp<TYPE>();
+    testCase2_Imp<const TYPE>();
 
 }
 

--- a/groups/bsl/bslstl/bslstl_optional.t.cpp
+++ b/groups/bsl/bslstl/bslstl_optional.t.cpp
@@ -1,13 +1,6 @@
 // bslstl_optional.t.cpp                                              -*-C++-*-
 
-// ----------------------------------------------------------------------------
-//                                   NOTICE
-//
-// This component is not up to date with current BDE coding standards, and
-// should not be used as an example for new development.
-// ----------------------------------------------------------------------------
-
-#include "bslstl_optional.h"
+#include <bslstl_optional.h>
 #include <bsls_bsltestutil.h>
 #include <bslstl_string.h>
 

--- a/groups/bsl/bslstl/bslstl_optional.t.cpp
+++ b/groups/bsl/bslstl/bslstl_optional.t.cpp
@@ -16,8 +16,8 @@
 #include <bslma_testallocator.h>
 #include <bslma_testallocatormonitor.h>
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 using namespace BloombergLP;
 using namespace bsl;
@@ -40,14 +40,13 @@ using namespace bsl;
 // is allocator aware or not, and thus the behaviour needs to be tested for
 // both allocator aware and non allocator aware value types.  One of the
 // guarantees this type provides is that no unnecessary copies of the value
-// type object are created when using this type as opposed to using a raw
-// value type object.  In order to test this guarantee, we use test types
-// designed to count the number of instances created.
+// type object are created when using this type as opposed to using a raw value
+// type object.  In order to test this guarantee, we use test types designed to
+// count the number of instances created.
 //
 //  Internal implementation types:
 // [ 1] 'Optional_Data' class
 // [ 2] 'Optional_DataImp' class
-
 
 // ============================================================================
 //                     STANDARD BSL ASSERT TEST FUNCTION
@@ -70,15 +69,14 @@ void aSsErT(bool condition, const char *message, int line)
 
 }  // close unnamed namespace
 
-
 // ============================================================================
 //               STANDARD BSL TEST DRIVER MACRO ABBREVIATIONS
 // ----------------------------------------------------------------------------
 
-#define ASSERT       BSLS_BSLTESTUTIL_ASSERT
-#define ASSERTV      BSLS_BSLTESTUTIL_ASSERTV
+#define ASSERT BSLS_BSLTESTUTIL_ASSERT
+#define ASSERTV BSLS_BSLTESTUTIL_ASSERTV
 
-#define LOOP_ASSERT  BSLS_BSLTESTUTIL_LOOP_ASSERT
+#define LOOP_ASSERT BSLS_BSLTESTUTIL_LOOP_ASSERT
 #define LOOP0_ASSERT BSLS_BSLTESTUTIL_LOOP0_ASSERT
 #define LOOP1_ASSERT BSLS_BSLTESTUTIL_LOOP1_ASSERT
 #define LOOP2_ASSERT BSLS_BSLTESTUTIL_LOOP2_ASSERT
@@ -87,19 +85,19 @@ void aSsErT(bool condition, const char *message, int line)
 #define LOOP5_ASSERT BSLS_BSLTESTUTIL_LOOP5_ASSERT
 #define LOOP6_ASSERT BSLS_BSLTESTUTIL_LOOP6_ASSERT
 
-#define Q            BSLS_BSLTESTUTIL_Q   // Quote identifier literally.
-#define P            BSLS_BSLTESTUTIL_P   // Print identifier and value.
-#define P_           BSLS_BSLTESTUTIL_P_  // P(X) without '\n'.
-#define T_           BSLS_BSLTESTUTIL_T_  // Print a tab (w/o newline).
-#define L_           BSLS_BSLTESTUTIL_L_  // current Line number
+#define Q BSLS_BSLTESTUTIL_Q    // Quote identifier literally.
+#define P BSLS_BSLTESTUTIL_P    // Print identifier and value.
+#define P_ BSLS_BSLTESTUTIL_P_  // P(X) without '\n'.
+#define T_ BSLS_BSLTESTUTIL_T_  // Print a tab (w/o newline).
+#define L_ BSLS_BSLTESTUTIL_L_  // current Line number
 
 // ============================================================================
 //                       GLOBAL TEST VALUES
 // ----------------------------------------------------------------------------
 
-static bool             verbose;
-static bool         veryVerbose;
-static bool     veryVeryVerbose;
+static bool verbose;
+static bool veryVerbose;
+static bool veryVeryVerbose;
 static bool veryVeryVeryVerbose;
 
 using namespace BloombergLP;
@@ -113,10 +111,9 @@ const int MOVED_FROM_VAL = 0x01d;
 //                  CLASSES FOR TESTING USAGE EXAMPLES
 //-----------------------------------------------------------------------------
 
-
-                             // =================
-                             // class MyClassDef
-                             // =================
+                              // ================
+                              // class MyClassDef
+                              // ================
 
 struct MyClassDef {
     // Data members that give MyClassX size and alignment.  This class is a
@@ -126,17 +123,17 @@ struct MyClassDef {
     // to allocate storage owned by this class.
 
     // DATA (exceptionally public, only in test driver)
-    int                         d_value;
-    int                        *d_data_p;
-    bslma::Allocator           *d_allocator_p;
+    int               d_value;
+    int              *d_data_p;
+    bslma::Allocator *d_allocator_p;
 };
 
 // In optimized builds, some compilers will elide some of the operations in the
 // destructors of the test classes defined below.  In order to force the
 // compiler to retain all of the code in the destructors, we provide the
 // following function that can be used to (conditionally) print out the state
-// of a 'MyClassDef' data member.  If the destructor calls this function as
-// its last operation, then all values set in the destructor have visible
+// of a 'MyClassDef' data member.  If the destructor calls this function as its
+// last operation, then all values set in the destructor have visible
 // side-effects, but non-verbose test runs do not have to be burdened with
 // additional output.
 
@@ -146,13 +143,16 @@ void dumpClassDefState(const MyClassDef& def)
 {
     if (forceDestructorCall) {
         printf("%p: %d %p %p\n",
-               &def, def.d_value, def.d_data_p, def.d_allocator_p);
+               &def,
+               def.d_value,
+               def.d_data_p,
+               def.d_allocator_p);
     }
 }
 
-                             // ===============
-                             // class MyClass1
-                             // ===============
+                               // ==============
+                               // class MyClass1
+                               // ==============
 
 struct MyClass1 {
     // This 'class' is a simple type that does not take allocators.  Its
@@ -164,7 +164,6 @@ struct MyClass1 {
     // unnecessary copies.  A signal value, 'MOVED_FROM_VAL', is used to detect
     // an object in a moved-from state.
 
-
     // DATA
     MyClassDef d_def;
 
@@ -173,28 +172,31 @@ struct MyClass1 {
     static int s_destructorInvocations;
 
     // CREATORS
-   //explicit
-    MyClass1(int v = 0) {                                           // IMPLICIT
-        d_def.d_value = v;
+    MyClass1(int v = 0)  // IMPLICIT
+    {
+        d_def.d_value       = v;
         d_def.d_allocator_p = 0;
     }
-    MyClass1(const MyClass1& rhs) {
-        d_def.d_value = rhs.d_def.d_value;
+    MyClass1(const MyClass1& rhs)
+    {
+        d_def.d_value       = rhs.d_def.d_value;
         d_def.d_allocator_p = 0;
         ++s_copyConstructorInvocations;
     }
 
-    MyClass1(bslmf::MovableRef<MyClass1> other) {
-        MyClass1& otherRef = MovUtl::access(other);
-        d_def.d_value = otherRef.d_def.d_value;
+    MyClass1(bslmf::MovableRef<MyClass1> other)
+    {
+        MyClass1& otherRef     = MovUtl::access(other);
+        d_def.d_value          = otherRef.d_def.d_value;
         otherRef.d_def.d_value = MOVED_FROM_VAL;
-        d_def.d_allocator_p = 0;
+        d_def.d_allocator_p    = 0;
         ++s_moveConstructorInvocations;
     }
 
-    ~MyClass1() {
+    ~MyClass1()
+    {
         ASSERT(d_def.d_value != 91);
-        d_def.d_value = 91;
+        d_def.d_value       = 91;
         d_def.d_allocator_p = 0;
         dumpClassDefState(d_def);
         ++s_destructorInvocations;
@@ -210,8 +212,8 @@ struct MyClass1 {
     MyClass1& operator=(bslmf::MovableRef<MyClass1> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        MyClass1& otherRef = MovUtl::access(rhs);
-        d_def.d_value = otherRef.d_def.d_value;
+        MyClass1& otherRef     = MovUtl::access(rhs);
+        d_def.d_value          = otherRef.d_def.d_value;
         otherRef.d_def.d_value = MOVED_FROM_VAL;
         return *this;
     }
@@ -224,48 +226,55 @@ struct MyClass1 {
     }
     // ACCESSORS
     int value() const { return d_def.d_value; }
-
 };
-bool operator==(const MyClass1& lhs,
-                const MyClass1& rhs)
+bool operator==(const MyClass1& lhs, const MyClass1& rhs)
 {
-    return (lhs.value()==rhs.value());
+    return (lhs.value() == rhs.value());
 }
 // CLASS DATA
-int MyClass1::s_copyConstructorInvocations       = 0;
-int MyClass1::s_moveConstructorInvocations       = 0;
-int MyClass1::s_destructorInvocations            = 0;
+int MyClass1::s_copyConstructorInvocations = 0;
+int MyClass1::s_moveConstructorInvocations = 0;
+int MyClass1::s_destructorInvocations      = 0;
 
-                             // ===============
-                             // class MyClass1a
-                             // ===============
+                              // ===============
+                              // class MyClass1a
+                              // ===============
 
 struct MyClass1a {
     // This 'class' is the same as My_Class1, except it also supports
     // conversion from My_Class1. This allows for testing of converting
     // constructors and assignment from a type convertible to value type.
 
-    MyClass1 d_data;
+    MyClass1   d_data;
     static int s_copyConstructorInvocations;
     static int s_moveConstructorInvocations;
 
     // CREATORS
 
-    explicit
-    MyClass1a(int v)  : d_data(v) {}                                // IMPLICIT
+    explicit MyClass1a(int v)  // IMPLICIT
+    : d_data(v)
+    {
+    }
 
-    MyClass1a(const MyClass1& v)                                    // IMPLICIT
-    : d_data(v) {}
+    MyClass1a(const MyClass1& v)  // IMPLICIT
+    : d_data(v)
+    {
+    }
 
-    MyClass1a(bslmf::MovableRef<MyClass1> v)                        // IMPLICIT
-    : d_data(MovUtl::move(MovUtl::access(v))) {}
+    MyClass1a(bslmf::MovableRef<MyClass1> v)  // IMPLICIT
+    : d_data(MovUtl::move(MovUtl::access(v)))
+    {
+    }
 
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
     MyClass1a(bslmf::MovableRef<const MyClass1> v)
-    : d_data(MovUtl::access(v)) {}                                  // IMPLICIT
-#endif //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
+    : d_data(MovUtl::access(v))
+    {
+    }   // IMPLICIT
+#endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
 
-    MyClass1a(const MyClass1a& rhs) : d_data(rhs.d_data)
+    MyClass1a(const MyClass1a& rhs)
+    : d_data(rhs.d_data)
     {
         ++s_copyConstructorInvocations;
     }
@@ -281,45 +290,44 @@ struct MyClass1a {
     {
         ++s_moveConstructorInvocations;
     }
-#endif //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
+#endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
 
-  // MANIPULATORS
+    // MANIPULATORS
     MyClass1a& operator=(const MyClass1a& rhs)
         // assign the value of specified 'rhs' to this object
     {
-        d_data.operator=(rhs.d_data);
+        d_data. operator=(rhs.d_data);
         return *this;
     }
 
     MyClass1a& operator=(bslmf::MovableRef<MyClass1a> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        d_data.operator=(MovUtl::move(MovUtl::access(rhs).d_data));
+        d_data. operator=(MovUtl::move(MovUtl::access(rhs).d_data));
         return *this;
     }
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
     MyClass1a& operator=(bslmf::MovableRef<const MyClass1a> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        d_data.operator=(MovUtl::access(rhs).d_data);
+        d_data. operator=(MovUtl::access(rhs).d_data);
         return *this;
     }
-#endif //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
+#endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
 
     // ACCESSORS
     int value() const { return d_data.value(); }
 };
 // CLASS DATA
-int MyClass1a::s_copyConstructorInvocations       = 0;
-int MyClass1a::s_moveConstructorInvocations       = 0;
-bool operator==(const MyClass1a& lhs,
-                const MyClass1a& rhs)
+int MyClass1a::s_copyConstructorInvocations = 0;
+int MyClass1a::s_moveConstructorInvocations = 0;
+bool operator==(const MyClass1a& lhs, const MyClass1a& rhs)
 {
-    return (lhs.value()==rhs.value());
+    return (lhs.value() == rhs.value());
 }
-                             // ===============
-                             // class MyClass2
-                             // ===============
+                               // ==============
+                               // class MyClass2
+                               // ==============
 
 struct MyClass2 {
     // This 'class' supports the 'bslma::UsesBslmaAllocator' trait, providing
@@ -341,26 +349,29 @@ struct MyClass2 {
     static int s_destructorInvocations;
 
     // CREATORS
-    explicit
-    MyClass2(bslma::Allocator *a = 0) {
-        d_def.d_value = 0;
+    explicit MyClass2(bslma::Allocator *a = 0)
+    {
+        d_def.d_value       = 0;
         d_def.d_allocator_p = a;
     }
 
-    MyClass2(int v, bslma::Allocator *a = 0) {                      // IMPLICIT
-        d_def.d_value = v;
+    MyClass2(int v, bslma::Allocator *a = 0)  // IMPLICIT
+    {
+        d_def.d_value       = v;
         d_def.d_allocator_p = a;
     }
-    MyClass2(const MyClass2& rhs, bslma::Allocator *a = 0) {        // IMPLICIT
-        d_def.d_value = rhs.d_def.d_value;
+    MyClass2(const MyClass2& rhs, bslma::Allocator *a = 0)  // IMPLICIT
+    {
+        d_def.d_value       = rhs.d_def.d_value;
         d_def.d_allocator_p = a;
         s_copyConstructorInvocations++;
     }
 
-    MyClass2(bslmf::MovableRef<MyClass2> other, bslma::Allocator *a = 0) {
-                                                                    // IMPLICIT
-        MyClass2& otherRef = MovUtl::access(other);
-        d_def.d_value = otherRef.d_def.d_value;
+    MyClass2(bslmf::MovableRef<MyClass2> other, bslma::Allocator *a = 0)
+    {
+        // IMPLICIT
+        MyClass2& otherRef     = MovUtl::access(other);
+        d_def.d_value          = otherRef.d_def.d_value;
         otherRef.d_def.d_value = MOVED_FROM_VAL;
         if (a) {
             d_def.d_allocator_p = a;
@@ -371,11 +382,11 @@ struct MyClass2 {
         s_moveConstructorInvocations++;
     }
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
-    MyClass2(bslmf::MovableRef<const MyClass2> other,
-             bslma::Allocator *a = 0) {                             // IMPLICIT
+    MyClass2(bslmf::MovableRef<const MyClass2> other, bslma::Allocator *a = 0)
+    {  // IMPLICIT
 
         const MyClass2& otherRef = MovUtl::access(other);
-        d_def.d_value = otherRef.d_def.d_value;
+        d_def.d_value            = otherRef.d_def.d_value;
         if (a) {
             d_def.d_allocator_p = a;
         }
@@ -384,33 +395,36 @@ struct MyClass2 {
         }
         s_moveConstructorInvocations++;
     }
-#endif //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
+#endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
 
-    MyClass2(const MyClass1& rhs, bslma::Allocator *a = 0) {        // IMPLICIT
-        d_def.d_value = rhs.d_def.d_value;
+    MyClass2(const MyClass1& rhs, bslma::Allocator *a = 0)  // IMPLICIT
+    {
+        d_def.d_value       = rhs.d_def.d_value;
         d_def.d_allocator_p = a;
     }
 
-    MyClass2(bslmf::MovableRef<MyClass1> other, bslma::Allocator *a = 0) {
-                                                                    // IMPLICIT
-        MyClass1& otherRef = MovUtl::access(other);
-        d_def.d_value = otherRef.d_def.d_value;
+    MyClass2(bslmf::MovableRef<MyClass1> other, bslma::Allocator *a = 0)
+        // IMPLICIT
+    {
+        MyClass1& otherRef     = MovUtl::access(other);
+        d_def.d_value          = otherRef.d_def.d_value;
         otherRef.d_def.d_value = MOVED_FROM_VAL;
-        d_def.d_allocator_p = a;
+        d_def.d_allocator_p    = a;
     }
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
-    MyClass2(bslmf::MovableRef<const MyClass1> other,
-             bslma::Allocator *a = 0) {                             // IMPLICIT
+    MyClass2(bslmf::MovableRef<const MyClass1> other, bslma::Allocator *a = 0)
+    {  // IMPLICIT
 
         const MyClass1& otherRef = MovUtl::access(other);
-        d_def.d_value = otherRef.d_def.d_value;
-        d_def.d_allocator_p = a;
+        d_def.d_value            = otherRef.d_def.d_value;
+        d_def.d_allocator_p      = a;
     }
-#endif //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
+#endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
 
-    ~MyClass2() {
+    ~MyClass2()
+    {
         ASSERT(d_def.d_value != 92);
-        d_def.d_value = 92;
+        d_def.d_value       = 92;
         d_def.d_allocator_p = 0;
         dumpClassDefState(d_def);
         ++s_destructorInvocations;
@@ -428,8 +442,8 @@ struct MyClass2 {
     MyClass2& operator=(bslmf::MovableRef<MyClass2> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        MyClass2& otherRef = MovUtl::access(rhs);
-        d_def.d_value = otherRef.d_def.d_value;
+        MyClass2& otherRef     = MovUtl::access(rhs);
+        d_def.d_value          = otherRef.d_def.d_value;
         otherRef.d_def.d_value = MOVED_FROM_VAL;
         // do not touch allocator!
         return *this;
@@ -440,11 +454,11 @@ struct MyClass2 {
         // assign the value of specified 'rhs' to this object
     {
         const MyClass2& otherRef = MovUtl::access(rhs);
-        d_def.d_value = otherRef.d_def.d_value;
+        d_def.d_value            = otherRef.d_def.d_value;
         // do not touch allocator!
         return *this;
     }
-#endif //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
+#endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
 
     MyClass2& operator=(int rhs)
         // assign the value of specified 'rhs' to this object
@@ -460,110 +474,90 @@ struct MyClass2 {
     int value() const { return d_def.d_value; }
 
     // returns the allocator used by this object
-    bsl::allocator<char> get_allocator() const {
-        return d_def.d_allocator_p;
-    }
+    bsl::allocator<char> get_allocator() const { return d_def.d_allocator_p; }
 };
 // CLASS DATA
-int MyClass2::s_copyConstructorInvocations       = 0;
-int MyClass2::s_moveConstructorInvocations       = 0;
-int MyClass2::s_destructorInvocations            = 0;
+int MyClass2::s_copyConstructorInvocations = 0;
+int MyClass2::s_moveConstructorInvocations = 0;
+int MyClass2::s_destructorInvocations      = 0;
 
-bool operator==(const MyClass2& lhs,
-                const MyClass2& rhs)
+bool operator==(const MyClass2& lhs, const MyClass2& rhs)
 {
-    return (lhs.value()==rhs.value());
-}
-
-bool operator==(const int&      lhs,
-                const MyClass2& rhs)
-{
-    return (lhs==rhs.value());
-}
-bool operator==(const MyClass2& lhs,
-                const int&      rhs)
-{
-    return (lhs.value()==rhs);
-}
-bool operator!=(const MyClass2& lhs,
-                const MyClass2& rhs)
-{
-    return !(lhs ==rhs);
+    return (lhs.value() == rhs.value());
 }
 
-bool operator!=(const int&      lhs,
-                const MyClass2& rhs)
+bool operator==(const int& lhs, const MyClass2& rhs)
 {
-    return !(lhs ==rhs);
+    return (lhs == rhs.value());
 }
-bool operator!=(const MyClass2& lhs,
-                const int&      rhs)
+bool operator==(const MyClass2& lhs, const int& rhs)
 {
-    return !(lhs ==rhs);
+    return (lhs.value() == rhs);
 }
-bool operator<(const MyClass2& lhs,
-               const MyClass2& rhs)
+bool operator!=(const MyClass2& lhs, const MyClass2& rhs)
 {
-    return (lhs.value()<rhs.value());
+    return !(lhs == rhs);
 }
 
-bool operator<(const int&      lhs,
-               const MyClass2& rhs)
+bool operator!=(const int& lhs, const MyClass2& rhs)
 {
-    return (lhs<rhs.value());
+    return !(lhs == rhs);
 }
-bool operator<(const MyClass2& lhs,
-               const int&      rhs)
+bool operator!=(const MyClass2& lhs, const int& rhs)
 {
-    return (lhs.value()<rhs);
+    return !(lhs == rhs);
 }
-bool operator>(const MyClass2& lhs,
-               const MyClass2& rhs)
+bool operator<(const MyClass2& lhs, const MyClass2& rhs)
 {
-    return (lhs.value()>rhs.value());
+    return (lhs.value() < rhs.value());
 }
 
-bool operator>(const int&      lhs,
-               const MyClass2& rhs)
+bool operator<(const int& lhs, const MyClass2& rhs)
 {
-    return (lhs>rhs.value());
+    return (lhs < rhs.value());
 }
-bool operator>(const MyClass2& lhs,
-               const int&      rhs)
+bool operator<(const MyClass2& lhs, const int& rhs)
 {
-    return (lhs.value()>rhs);
+    return (lhs.value() < rhs);
 }
-bool operator<=(const MyClass2& lhs,
-                const MyClass2& rhs)
+bool operator>(const MyClass2& lhs, const MyClass2& rhs)
 {
-    return (lhs.value()<=rhs.value());
+    return (lhs.value() > rhs.value());
 }
 
-bool operator<=(const int&      lhs,
-                const MyClass2& rhs)
+bool operator>(const int& lhs, const MyClass2& rhs)
 {
-    return (lhs<=rhs.value());
+    return (lhs > rhs.value());
 }
-bool operator<=(const MyClass2& lhs,
-                const int&      rhs)
+bool operator>(const MyClass2& lhs, const int& rhs)
 {
-    return (lhs.value()<=rhs);
+    return (lhs.value() > rhs);
 }
-bool operator>=(const MyClass2& lhs,
-                const MyClass2& rhs)
+bool operator<=(const MyClass2& lhs, const MyClass2& rhs)
 {
-    return (lhs.value()>=rhs.value());
+    return (lhs.value() <= rhs.value());
 }
 
-bool operator>=(const int&      lhs,
-                const MyClass2& rhs)
+bool operator<=(const int& lhs, const MyClass2& rhs)
 {
-    return (lhs>=rhs.value());
+    return (lhs <= rhs.value());
 }
-bool operator>=(const MyClass2& lhs,
-                const int&      rhs)
+bool operator<=(const MyClass2& lhs, const int& rhs)
 {
-    return (lhs.value()>=rhs);
+    return (lhs.value() <= rhs);
+}
+bool operator>=(const MyClass2& lhs, const MyClass2& rhs)
+{
+    return (lhs.value() >= rhs.value());
+}
+
+bool operator>=(const int& lhs, const MyClass2& rhs)
+{
+    return (lhs >= rhs.value());
+}
+bool operator>=(const MyClass2& lhs, const int& rhs)
+{
+    return (lhs.value() >= rhs);
 }
 
 // TRAITS
@@ -571,14 +565,15 @@ namespace BloombergLP {
 namespace bslma {
 
 template <>
-struct UsesBslmaAllocator<MyClass2> : bsl::true_type { };
+struct UsesBslmaAllocator<MyClass2> : bsl::true_type {
+};
 
 }  // close namespace bslma
 }  // close enterprise namespace
 
-                                 // ==========
+                                 // =========
                                  // MyClass2a
-                                 // ==========
+                                 // =========
 
 struct MyClass2a {
     // This 'class' behaves the same as 'MyClass2' (allocator-aware type that
@@ -586,78 +581,100 @@ struct MyClass2a {
     // 'allocator_arg_t' idiom for passing an allocator to constructors.  This
     // class is constructible and assignable from MyClass2
 
-    MyClass2 d_data;
+    MyClass2   d_data;
 
     static int s_copyConstructorInvocations;
     static int s_moveConstructorInvocations;
 
     // CREATORS
-    MyClass2a() : d_data() { }
+    MyClass2a()
+    : d_data()
+    {
+    }
 
-    MyClass2a(bsl::allocator_arg_t, bslma::Allocator *a) : d_data(a) {}
+    MyClass2a(bsl::allocator_arg_t, bslma::Allocator *a)
+    : d_data(a)
+    {
+    }
 
-    explicit
-    MyClass2a(int v)  : d_data(v) {}                                // IMPLICIT
+    explicit MyClass2a(int v)  // IMPLICIT
+    : d_data(v)
+    {
+    }
 
-    MyClass2a(const MyClass2& rhs) : d_data(rhs) {}                 // IMPLICIT
+    MyClass2a(const MyClass2& rhs)  // IMPLICIT
+    : d_data(rhs)
+    {
+    }
 
-    MyClass2a(bslmf::MovableRef<MyClass2> rhs)                      // IMPLICIT
-      : d_data(MovUtl::move(MovUtl::access(rhs))) {}
+    MyClass2a(bslmf::MovableRef<MyClass2> rhs)  // IMPLICIT
+    : d_data(MovUtl::move(MovUtl::access(rhs)))
+    {
+    }
 
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
-    MyClass2a(bslmf::MovableRef<const MyClass2> rhs)                // IMPLICIT
-      : d_data(MovUtl::access(rhs)) {}
-#endif //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
+    MyClass2a(bslmf::MovableRef<const MyClass2> rhs)  // IMPLICIT
+    : d_data(MovUtl::access(rhs))
+    {
+    }
+#endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
 
     MyClass2a(bsl::allocator_arg_t, bslma::Allocator *a, int v)
-        : d_data(v, a) {}
+    : d_data(v, a)
+    {
+    }
 
     MyClass2a(bsl::allocator_arg_t, bslma::Allocator *a, const MyClass2& v)
-            : d_data(v, a) {}
+    : d_data(v, a)
+    {
+    }
 
     MyClass2a(bsl::allocator_arg_t,
-              bslma::Allocator           *a,
-              bslmf::MovableRef<MyClass2> v)
-            : d_data(MovUtl::move(MovUtl::access(v)), a) {}
+              bslma::Allocator            *a,
+              bslmf::MovableRef<MyClass2>  v)
+    : d_data(MovUtl::move(MovUtl::access(v)), a)
+    {
+    }
 
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
     MyClass2a(bsl::allocator_arg_t,
-              bslma::Allocator                 *a,
-              bslmf::MovableRef<const MyClass2> v)
-            : d_data(MovUtl::access(v), a) {}
-#endif //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
+              bslma::Allocator                  *a,
+              bslmf::MovableRef<const MyClass2>  v)
+    : d_data(MovUtl::access(v), a)
+    {
+    }
+#endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
 
-    MyClass2a(const MyClass2a& rhs) : d_data(rhs.d_data)
+    MyClass2a(const MyClass2a& rhs)
+    : d_data(rhs.d_data)
     {
         ++s_copyConstructorInvocations;
     }
 
-    MyClass2a(bsl::allocator_arg_t  ,
-              bslma::Allocator    *a,
-              const MyClass2a&     rhs)
-        : d_data(rhs.d_data, a)
+    MyClass2a(bsl::allocator_arg_t, bslma::Allocator *a, const MyClass2a& rhs)
+    : d_data(rhs.d_data, a)
     {
         ++s_copyConstructorInvocations;
     }
 
     MyClass2a(bslmf::MovableRef<MyClass2a> rhs)
-        : d_data(MovUtl::move(MovUtl::access(rhs).d_data))
+    : d_data(MovUtl::move(MovUtl::access(rhs).d_data))
     {
         ++s_moveConstructorInvocations;
     }
 
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
     MyClass2a(bslmf::MovableRef<const MyClass2a> rhs)
-        : d_data(MovUtl::access(rhs).d_data)
+    : d_data(MovUtl::access(rhs).d_data)
     {
         ++s_copyConstructorInvocations;
     }
-#endif //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
+#endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
 
     MyClass2a(bsl::allocator_arg_t,
               bslma::Allocator             *a,
               bslmf::MovableRef<MyClass2a>  rhs)
-        : d_data(MovUtl::move(MovUtl::access(rhs).d_data), a)
+    : d_data(MovUtl::move(MovUtl::access(rhs).d_data), a)
     {
         ++s_moveConstructorInvocations;
     }
@@ -666,25 +683,25 @@ struct MyClass2a {
     MyClass2a(bsl::allocator_arg_t,
               bslma::Allocator                   *a,
               bslmf::MovableRef<const MyClass2a>  rhs)
-        : d_data(MovUtl::access(rhs).d_data, a)
+    : d_data(MovUtl::access(rhs).d_data, a)
     {
         ++s_copyConstructorInvocations;
     }
 
-#endif //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
+#endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
 
     // MANIPULATORS
     MyClass2a& operator=(const MyClass2a& rhs)
         // assign the value of specified 'rhs' to this object
     {
-        d_data.operator=(rhs.d_data);
+        d_data. operator=(rhs.d_data);
         return *this;
     }
 
     MyClass2a& operator=(bslmf::MovableRef<MyClass2a> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        d_data.operator=(MovUtl::move(MovUtl::access(rhs).d_data));
+        d_data. operator=(MovUtl::move(MovUtl::access(rhs).d_data));
         return *this;
     }
 
@@ -692,15 +709,15 @@ struct MyClass2a {
     MyClass2a& operator=(bslmf::MovableRef<const MyClass2a> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        d_data.operator=(MovUtl::access(rhs).d_data);
+        d_data. operator=(MovUtl::access(rhs).d_data);
         return *this;
     }
 
-#endif //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
+#endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
     MyClass2a& operator=(int rhs)
         // assign the value of specified 'rhs' to this object
     {
-        d_data.operator=(rhs);
+        d_data. operator=(rhs);
         return *this;
     }
     // ACCESSORS
@@ -709,53 +726,63 @@ struct MyClass2a {
     int value() const { return d_data.value(); }
 
     // returns the allocator used for this object
-    bsl::allocator<char> get_allocator() const {
+    bsl::allocator<char> get_allocator() const
+    {
         return d_data.get_allocator();
     }
 };
 
-bool operator==(const MyClass2a& lhs,
-                const MyClass2a& rhs)
+bool operator==(const MyClass2a& lhs, const MyClass2a& rhs)
     // Check if specified 'lhs' matches the specified 'rhs'
 {
-    return (lhs.value()==rhs.value());
+    return (lhs.value() == rhs.value());
 }
-int MyClass2a::s_copyConstructorInvocations       = 0;
-int MyClass2a::s_moveConstructorInvocations       = 0;
+int MyClass2a::s_copyConstructorInvocations = 0;
+int MyClass2a::s_moveConstructorInvocations = 0;
 // TRAITS
 namespace BloombergLP {
 
 namespace bslma {
-template <> struct UsesBslmaAllocator<MyClass2a> : bsl::true_type { };
+template <>
+struct UsesBslmaAllocator<MyClass2a> : bsl::true_type {
+};
 }  // close namespace bslma
 
 namespace bslmf {
-template <> struct UsesAllocatorArgT<MyClass2a> : bsl::true_type { };
+template <>
+struct UsesAllocatorArgT<MyClass2a> : bsl::true_type {
+};
 }  // close namespace bslmf
 
 }  // close enterprise namespace
 
 // helper functions to determine the constness of a pointer
-template<class TYPE>
-bool isConstPtr( TYPE*) { return false;}
-template<class TYPE>
-bool isConstPtr(const TYPE*) { return true;}
+template <class TYPE>
+bool isConstPtr(TYPE *)
+{
+    return false;
+}
+template <class TYPE>
+bool isConstPtr(const TYPE *)
+{
+    return true;
+}
 
-
-template <class TYPE, bool USES_BSLMA_ALLOC =
-                           BloombergLP::bslma::UsesBslmaAllocator<TYPE>::value>
+template <class TYPE,
+          bool USES_BSLMA_ALLOC =
+              BloombergLP::bslma::UsesBslmaAllocator<TYPE>::value>
 class Test_Util {
     // This class provided test utilities that have different behaviour
     // depending on whether 'TYPE is allocator aware or not.  The main template
     // is for allocator aware types.
 
   public:
-    static bool checkAllocator(const TYPE                 &obj,
-                               const bsl::allocator<char> &expected);
-        // Check if, for the specified 'obj', 'obj.get_allocator()' returns
-        // the specified 'expected' allocator.
+    static bool checkAllocator(const TYPE&                 obj,
+                               const bsl::allocator<char>& expected);
+        // Check if, for the specified 'obj', 'obj.get_allocator()' returns the
+        // specified 'expected' allocator.
 
-    static bool hasSameAllocator(const TYPE &obj, const TYPE &other);
+    static bool hasSameAllocator(const TYPE& obj, const TYPE& other);
         // Check if, for the specified 'obj' and specified 'other',
         // 'obj.get_allocator() == other.get_allocator()';
 };
@@ -767,31 +794,29 @@ class Test_Util<TYPE, false> {
     // specialization is for non allocator aware types.
 
   public:
-    static bool checkAllocator(const TYPE &,const bsl::allocator<char>&);
+    static bool checkAllocator(const TYPE&, const bsl::allocator<char>&);
         // return 'true'.
 
-    static bool hasSameAllocator(const TYPE &,const TYPE &);
+    static bool hasSameAllocator(const TYPE&, const TYPE&);
         // return 'true'.
-
 };
 
 template <class TYPE, bool USES_BSLMA_ALLOC>
-inline bool
-Test_Util<TYPE, USES_BSLMA_ALLOC>::checkAllocator(
-                                          const TYPE                 &obj,
-                                          const bsl::allocator<char> &expected)
+inline
+bool Test_Util<TYPE, USES_BSLMA_ALLOC>::checkAllocator(
+                                          const TYPE&                 obj,
+                                          const bsl::allocator<char>& expected)
 {
     return (expected == obj.get_allocator());
 }
 
 template <class TYPE, bool USES_BSLMA_ALLOC>
-inline bool
-Test_Util<TYPE, USES_BSLMA_ALLOC>::hasSameAllocator(const TYPE &obj,
-                                                    const TYPE &other)
+inline
+bool Test_Util<TYPE, USES_BSLMA_ALLOC>::hasSameAllocator(const TYPE& obj,
+                                                         const TYPE& other)
 {
     return (obj.get_allocator() == other.get_allocator());
 }
-
 
 template <class TYPE>
 inline bool
@@ -808,25 +833,24 @@ Test_Util<TYPE, false>::hasSameAllocator(const TYPE&, const TYPE&)
     return true;
 }
 
-template<class TYPE>
-bool checkAllocator(const TYPE &obj,const bsl::allocator<char> &allocator)
+template <class TYPE>
+bool checkAllocator(const TYPE& obj, const bsl::allocator<char>& allocator)
     // check that the specified 'obj' uses the specified 'allocator'.
 {
-    return Test_Util<TYPE>::checkAllocator(obj,allocator);
+    return Test_Util<TYPE>::checkAllocator(obj, allocator);
 }
 
-template<class TYPE>
-bool hasSameAllocator(const TYPE &obj1, const TYPE &obj2)
+template <class TYPE>
+bool hasSameAllocator(const TYPE& obj1, const TYPE& obj2)
     // check that the specified 'obj1' and specified 'obj2' use the same
     // allocator.
 {
-    return Test_Util<TYPE>::hasSameAllocator(obj1,obj2);
+    return Test_Util<TYPE>::hasSameAllocator(obj1, obj2);
 }
 
 // ============================================================================
 //                          TEST DRIVER TEMPLATE
 // ----------------------------------------------------------------------------
-
 
 template <class TYPE>
 class TestDriver {
@@ -838,13 +862,11 @@ class TestDriver {
 
     static void bslstl_optional_test2();
         // Optional_DataImp TEST
-
 };
 
 template <class TYPE>
 void TestDriver<TYPE>::bslstl_optional_test1()
 {
-
     // --------------------------------------------------------------------
     // 'Optional_Data' TEST
     //  This case exercises the functionality of 'Optional_Data' internal
@@ -859,27 +881,28 @@ void TestDriver<TYPE>::bslstl_optional_test1()
     //: 1 Compare 'std::is_trivially_destructible' trait for 'TYPE' and for
     //:   'Optional_Data<TYPE>'.  In C++03 mode, use
     //:   'bsl::is_trivially_copyable' trait instead.
+    //
     // Testing:
     //   'Optional_Data' class
     // --------------------------------------------------------------------
-    if (verbose) printf("\n'Optional_Data' TEST"
-                        "\n=================== \n");
+    if (verbose)
+        printf("\n'Optional_Data' TEST"
+               "\n=================== \n");
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
     ASSERT(std::is_trivially_destructible<TYPE>::value ==
            std::is_trivially_destructible<
-                            BloombergLP::bslstl::Optional_Data<TYPE> >::value);
+               BloombergLP::bslstl::Optional_Data<TYPE> >::value);
 #else
     ASSERT(bsl::is_trivially_copyable<TYPE>::value ==
            bsl::is_trivially_copyable<
-                            BloombergLP::bslstl::Optional_Data<TYPE> >::value);
-#endif // BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
+               BloombergLP::bslstl::Optional_Data<TYPE> >::value);
+#endif  // BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
 }
 
 template <class TYPE>
 void TestDriver<TYPE>::bslstl_optional_test2()
 {
-
     // --------------------------------------------------------------------
     // 'Optional_DataImp' TEST
     //   This case exercises (but does not fully test) the functionality of
@@ -907,8 +930,9 @@ void TestDriver<TYPE>::bslstl_optional_test2()
     //   'Optional_DataImp' class
     // --------------------------------------------------------------------
 
-    if (verbose) printf("\n'Optional_DataImp' TEST"
-                        "\n=======================\n");
+    if (verbose)
+        printf("\n'Optional_DataImp' TEST"
+               "\n=======================\n");
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
 
@@ -925,7 +949,6 @@ void TestDriver<TYPE>::bslstl_optional_test2()
 
     X.reset();
     ASSERT(!X.hasValue());
-
 }
 //=============================================================================
 //                              MAIN PROGRAM
@@ -933,23 +956,27 @@ void TestDriver<TYPE>::bslstl_optional_test2()
 
 int main(int argc, char **argv)
 {
-    const int                 test = argc > 1 ? atoi(argv[1]) : 0;
-    verbose = argc > 2;
-    veryVerbose = argc > 3;
-    veryVeryVerbose = argc > 4;
+    const int test      = argc > 1 ? atoi(argv[1]) : 0;
+    verbose             = argc > 2;
+    veryVerbose         = argc > 3;
+    veryVeryVerbose     = argc > 4;
     veryVeryVeryVerbose = argc > 5;
 
+    printf("TEST  %s CASE %d \n", __FILE__, test);
 
-    printf( "TEST  %s CASE %d \n", __FILE__, test );
-
-    switch (test) { case 0:
+    switch (test) {
+      case 0:
       case 2: {
         // --------------------------------------------------------------------
         // 'Optional_DataImp' TEST
         // --------------------------------------------------------------------
 
-        if (verbose) printf("\n" "'Optional_DataImp' TEST" "\n"
-                                 "=======================" "\n");
+        if (verbose)
+            printf("\n"
+                   "'Optional_DataImp' TEST"
+                   "\n"
+                   "======================="
+                   "\n");
 
         TestDriver<int>::bslstl_optional_test2();
         TestDriver<MyClass1>::bslstl_optional_test2();
@@ -959,14 +986,18 @@ int main(int argc, char **argv)
         TestDriver<const MyClass1>::bslstl_optional_test2();
         TestDriver<const MyClass2>::bslstl_optional_test2();
         TestDriver<const MyClass2a>::bslstl_optional_test2();
-      }  break;
+      } break;
       case 1: {
         // --------------------------------------------------------------------
         // 'Optional_Data' TEST
         // --------------------------------------------------------------------
 
-        if (verbose) printf("\n" "'Optional_Data' TEST" "\n"
-                                 "====================" "\n");
+        if (verbose)
+            printf("\n"
+                   "'Optional_Data' TEST"
+                   "\n"
+                   "===================="
+                   "\n");
 
         TestDriver<int>::bslstl_optional_test1();
         TestDriver<const int>::bslstl_optional_test1();
@@ -975,13 +1006,13 @@ int main(int argc, char **argv)
         TestDriver<MyClass2a>::bslstl_optional_test1();
       } break;
       default: {
-        printf( "WARNING: CASE `%d' NOT FOUND.\n", test);
+        printf("WARNING: CASE `%d' NOT FOUND.\n", test);
         testStatus = -1;
       }
     }
 
     if (testStatus > 0) {
-        printf( "Error, non-zero test status = %d .\n", testStatus);
+        printf("Error, non-zero test status = %d .\n", testStatus);
     }
     return testStatus;
 }

--- a/groups/bsl/bslstl/bslstl_optional.t.cpp
+++ b/groups/bsl/bslstl/bslstl_optional.t.cpp
@@ -69,14 +69,15 @@ void aSsErT(bool condition, const char *message, int line)
 
 }  // close unnamed namespace
 
+
 // ============================================================================
 //               STANDARD BSL TEST DRIVER MACRO ABBREVIATIONS
 // ----------------------------------------------------------------------------
 
-#define ASSERT BSLS_BSLTESTUTIL_ASSERT
-#define ASSERTV BSLS_BSLTESTUTIL_ASSERTV
+#define ASSERT       BSLS_BSLTESTUTIL_ASSERT
+#define ASSERTV      BSLS_BSLTESTUTIL_ASSERTV
 
-#define LOOP_ASSERT BSLS_BSLTESTUTIL_LOOP_ASSERT
+#define LOOP_ASSERT  BSLS_BSLTESTUTIL_LOOP_ASSERT
 #define LOOP0_ASSERT BSLS_BSLTESTUTIL_LOOP0_ASSERT
 #define LOOP1_ASSERT BSLS_BSLTESTUTIL_LOOP1_ASSERT
 #define LOOP2_ASSERT BSLS_BSLTESTUTIL_LOOP2_ASSERT
@@ -85,27 +86,31 @@ void aSsErT(bool condition, const char *message, int line)
 #define LOOP5_ASSERT BSLS_BSLTESTUTIL_LOOP5_ASSERT
 #define LOOP6_ASSERT BSLS_BSLTESTUTIL_LOOP6_ASSERT
 
-#define Q BSLS_BSLTESTUTIL_Q    // Quote identifier literally.
-#define P BSLS_BSLTESTUTIL_P    // Print identifier and value.
-#define P_ BSLS_BSLTESTUTIL_P_  // P(X) without '\n'.
-#define T_ BSLS_BSLTESTUTIL_T_  // Print a tab (w/o newline).
-#define L_ BSLS_BSLTESTUTIL_L_  // current Line number
+#define Q            BSLS_BSLTESTUTIL_Q   // Quote identifier literally.
+#define P            BSLS_BSLTESTUTIL_P   // Print identifier and value.
+#define P_           BSLS_BSLTESTUTIL_P_  // P(X) without '\n'.
+#define T_           BSLS_BSLTESTUTIL_T_  // Print a tab (w/o newline).
+#define L_           BSLS_BSLTESTUTIL_L_  // current Line number
 
 // ============================================================================
 //                       GLOBAL TEST VALUES
 // ----------------------------------------------------------------------------
 
-static bool verbose;
-static bool veryVerbose;
-static bool veryVeryVerbose;
+static bool             verbose;
+static bool         veryVerbose;
+static bool     veryVeryVerbose;
 static bool veryVeryVeryVerbose;
 
 using namespace BloombergLP;
 using namespace bsl;
 
-typedef bslmf::MovableRefUtil MovUtl;
+typedef bslmf::MovableRefUtil MoveUtil;
+
+namespace {
 
 const int MOVED_FROM_VAL = 0x01d;
+
+}  // close unnamed namespace
 
 //=============================================================================
 //                  CLASSES FOR TESTING USAGE EXAMPLES
@@ -186,7 +191,7 @@ struct MyClass1 {
 
     MyClass1(bslmf::MovableRef<MyClass1> other)
     {
-        MyClass1& otherRef     = MovUtl::access(other);
+        MyClass1& otherRef     = MoveUtil::access(other);
         d_def.d_value          = otherRef.d_def.d_value;
         otherRef.d_def.d_value = MOVED_FROM_VAL;
         d_def.d_allocator_p    = 0;
@@ -212,7 +217,7 @@ struct MyClass1 {
     MyClass1& operator=(bslmf::MovableRef<MyClass1> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        MyClass1& otherRef     = MovUtl::access(rhs);
+        MyClass1& otherRef     = MoveUtil::access(rhs);
         d_def.d_value          = otherRef.d_def.d_value;
         otherRef.d_def.d_value = MOVED_FROM_VAL;
         return *this;
@@ -262,13 +267,13 @@ struct MyClass1a {
     }
 
     MyClass1a(bslmf::MovableRef<MyClass1> v)  // IMPLICIT
-    : d_data(MovUtl::move(MovUtl::access(v)))
+    : d_data(MoveUtil::move(MoveUtil::access(v)))
     {
     }
 
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
     MyClass1a(bslmf::MovableRef<const MyClass1> v)
-    : d_data(MovUtl::access(v))
+    : d_data(MoveUtil::access(v))
     {
     }   // IMPLICIT
 #endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
@@ -280,13 +285,13 @@ struct MyClass1a {
     }
 
     MyClass1a(bslmf::MovableRef<MyClass1a> rhs)
-    : d_data(MovUtl::move(MovUtl::access(rhs).d_data))
+    : d_data(MoveUtil::move(MoveUtil::access(rhs).d_data))
     {
         ++s_moveConstructorInvocations;
     }
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
     MyClass1a(bslmf::MovableRef<const MyClass1a> rhs)
-    : d_data(MovUtl::access(rhs).d_data)
+    : d_data(MoveUtil::access(rhs).d_data)
     {
         ++s_moveConstructorInvocations;
     }
@@ -303,14 +308,14 @@ struct MyClass1a {
     MyClass1a& operator=(bslmf::MovableRef<MyClass1a> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        d_data. operator=(MovUtl::move(MovUtl::access(rhs).d_data));
+        d_data. operator=(MoveUtil::move(MoveUtil::access(rhs).d_data));
         return *this;
     }
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
     MyClass1a& operator=(bslmf::MovableRef<const MyClass1a> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        d_data. operator=(MovUtl::access(rhs).d_data);
+        d_data. operator=(MoveUtil::access(rhs).d_data);
         return *this;
     }
 #endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
@@ -370,7 +375,7 @@ struct MyClass2 {
     MyClass2(bslmf::MovableRef<MyClass2> other, bslma::Allocator *a = 0)
     {
         // IMPLICIT
-        MyClass2& otherRef     = MovUtl::access(other);
+        MyClass2& otherRef     = MoveUtil::access(other);
         d_def.d_value          = otherRef.d_def.d_value;
         otherRef.d_def.d_value = MOVED_FROM_VAL;
         if (a) {
@@ -385,7 +390,7 @@ struct MyClass2 {
     MyClass2(bslmf::MovableRef<const MyClass2> other, bslma::Allocator *a = 0)
     {  // IMPLICIT
 
-        const MyClass2& otherRef = MovUtl::access(other);
+        const MyClass2& otherRef = MoveUtil::access(other);
         d_def.d_value            = otherRef.d_def.d_value;
         if (a) {
             d_def.d_allocator_p = a;
@@ -406,7 +411,7 @@ struct MyClass2 {
     MyClass2(bslmf::MovableRef<MyClass1> other, bslma::Allocator *a = 0)
         // IMPLICIT
     {
-        MyClass1& otherRef     = MovUtl::access(other);
+        MyClass1& otherRef     = MoveUtil::access(other);
         d_def.d_value          = otherRef.d_def.d_value;
         otherRef.d_def.d_value = MOVED_FROM_VAL;
         d_def.d_allocator_p    = a;
@@ -415,7 +420,7 @@ struct MyClass2 {
     MyClass2(bslmf::MovableRef<const MyClass1> other, bslma::Allocator *a = 0)
     {  // IMPLICIT
 
-        const MyClass1& otherRef = MovUtl::access(other);
+        const MyClass1& otherRef = MoveUtil::access(other);
         d_def.d_value            = otherRef.d_def.d_value;
         d_def.d_allocator_p      = a;
     }
@@ -442,7 +447,7 @@ struct MyClass2 {
     MyClass2& operator=(bslmf::MovableRef<MyClass2> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        MyClass2& otherRef     = MovUtl::access(rhs);
+        MyClass2& otherRef     = MoveUtil::access(rhs);
         d_def.d_value          = otherRef.d_def.d_value;
         otherRef.d_def.d_value = MOVED_FROM_VAL;
         // do not touch allocator!
@@ -453,7 +458,7 @@ struct MyClass2 {
     MyClass2& operator=(bslmf::MovableRef<const MyClass2> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        const MyClass2& otherRef = MovUtl::access(rhs);
+        const MyClass2& otherRef = MoveUtil::access(rhs);
         d_def.d_value            = otherRef.d_def.d_value;
         // do not touch allocator!
         return *this;
@@ -608,13 +613,13 @@ struct MyClass2a {
     }
 
     MyClass2a(bslmf::MovableRef<MyClass2> rhs)  // IMPLICIT
-    : d_data(MovUtl::move(MovUtl::access(rhs)))
+    : d_data(MoveUtil::move(MoveUtil::access(rhs)))
     {
     }
 
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
     MyClass2a(bslmf::MovableRef<const MyClass2> rhs)  // IMPLICIT
-    : d_data(MovUtl::access(rhs))
+    : d_data(MoveUtil::access(rhs))
     {
     }
 #endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
@@ -632,7 +637,7 @@ struct MyClass2a {
     MyClass2a(bsl::allocator_arg_t,
               bslma::Allocator            *a,
               bslmf::MovableRef<MyClass2>  v)
-    : d_data(MovUtl::move(MovUtl::access(v)), a)
+    : d_data(MoveUtil::move(MoveUtil::access(v)), a)
     {
     }
 
@@ -640,7 +645,7 @@ struct MyClass2a {
     MyClass2a(bsl::allocator_arg_t,
               bslma::Allocator                  *a,
               bslmf::MovableRef<const MyClass2>  v)
-    : d_data(MovUtl::access(v), a)
+    : d_data(MoveUtil::access(v), a)
     {
     }
 #endif  //#ifdef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
@@ -658,14 +663,14 @@ struct MyClass2a {
     }
 
     MyClass2a(bslmf::MovableRef<MyClass2a> rhs)
-    : d_data(MovUtl::move(MovUtl::access(rhs).d_data))
+    : d_data(MoveUtil::move(MoveUtil::access(rhs).d_data))
     {
         ++s_moveConstructorInvocations;
     }
 
 #ifndef BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES
     MyClass2a(bslmf::MovableRef<const MyClass2a> rhs)
-    : d_data(MovUtl::access(rhs).d_data)
+    : d_data(MoveUtil::access(rhs).d_data)
     {
         ++s_copyConstructorInvocations;
     }
@@ -674,7 +679,7 @@ struct MyClass2a {
     MyClass2a(bsl::allocator_arg_t,
               bslma::Allocator             *a,
               bslmf::MovableRef<MyClass2a>  rhs)
-    : d_data(MovUtl::move(MovUtl::access(rhs).d_data), a)
+    : d_data(MoveUtil::move(MoveUtil::access(rhs).d_data), a)
     {
         ++s_moveConstructorInvocations;
     }
@@ -683,7 +688,7 @@ struct MyClass2a {
     MyClass2a(bsl::allocator_arg_t,
               bslma::Allocator                   *a,
               bslmf::MovableRef<const MyClass2a>  rhs)
-    : d_data(MovUtl::access(rhs).d_data, a)
+    : d_data(MoveUtil::access(rhs).d_data, a)
     {
         ++s_copyConstructorInvocations;
     }
@@ -701,7 +706,7 @@ struct MyClass2a {
     MyClass2a& operator=(bslmf::MovableRef<MyClass2a> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        d_data. operator=(MovUtl::move(MovUtl::access(rhs).d_data));
+        d_data. operator=(MoveUtil::move(MoveUtil::access(rhs).d_data));
         return *this;
     }
 
@@ -709,7 +714,7 @@ struct MyClass2a {
     MyClass2a& operator=(bslmf::MovableRef<const MyClass2a> rhs)
         // assign the value of specified 'rhs' to this object
     {
-        d_data. operator=(MovUtl::access(rhs).d_data);
+        d_data. operator=(MoveUtil::access(rhs).d_data);
         return *this;
     }
 

--- a/groups/bsl/bslstl/bslstl_optional.t.cpp
+++ b/groups/bsl/bslstl/bslstl_optional.t.cpp
@@ -9,6 +9,8 @@
 #include <bslma_testallocator.h>
 #include <bslma_testallocatormonitor.h>
 
+#include <bsltf_templatetestfacility.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -84,6 +86,8 @@ void aSsErT(bool condition, const char *message, int line)
 #define P_           BSLS_BSLTESTUTIL_P_  // P(X) without '\n'.
 #define T_           BSLS_BSLTESTUTIL_T_  // Print a tab (w/o newline).
 #define L_           BSLS_BSLTESTUTIL_L_  // current Line number
+
+#define RUN_EACH_TYPE BSLTF_TEMPLATETESTFACILITY_RUN_EACH_TYPE
 
 // ============================================================================
 //                       GLOBAL TEST VALUES
@@ -855,51 +859,17 @@ class TestDriver {
     // This class template provides a namespace for testing the 'optional'
     // type.
   public:
-    static void bslstl_optional_test1();
+    static void testCase2();
+        // Optional_DataImp TEST.  The test requires TYPE to be default
+        // constructible.
+
+    static void testCase1();
         // Optional_Data TEST
 
-    static void bslstl_optional_test2();
-        // Optional_DataImp TEST
 };
 
 template <class TYPE>
-void TestDriver<TYPE>::bslstl_optional_test1()
-{
-    // --------------------------------------------------------------------
-    // 'Optional_Data' TEST
-    //  This case exercises the functionality of 'Optional_Data' internal
-    //  class.  'Optional_Data' allows 'bsl::optional' objects to be trivially
-    //  destructible if 'TYPE' is trivially destructible.
-    //
-    // Concerns:
-    //: 1 'Optional_Data<TYPE>' object is trivially destructible if 'TYPE' is
-    //:    trivially destructible.
-    //
-    // Plan:
-    //: 1 Compare 'std::is_trivially_destructible' trait for 'TYPE' and for
-    //:   'Optional_Data<TYPE>'.  In C++03 mode, use
-    //:   'bsl::is_trivially_copyable' trait instead.
-    //
-    // Testing:
-    //   'Optional_Data' class
-    // --------------------------------------------------------------------
-    if (verbose)
-        printf("\n'Optional_Data' TEST"
-               "\n=================== \n");
-
-#ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
-    ASSERT(std::is_trivially_destructible<TYPE>::value ==
-           std::is_trivially_destructible<
-               BloombergLP::bslstl::Optional_Data<TYPE> >::value);
-#else
-    ASSERT(bsl::is_trivially_copyable<TYPE>::value ==
-           bsl::is_trivially_copyable<
-               BloombergLP::bslstl::Optional_Data<TYPE> >::value);
-#endif  // BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
-}
-
-template <class TYPE>
-void TestDriver<TYPE>::bslstl_optional_test2()
+void TestDriver<TYPE>::testCase2()
 {
     // --------------------------------------------------------------------
     // 'Optional_DataImp' TEST
@@ -934,6 +904,8 @@ void TestDriver<TYPE>::bslstl_optional_test2()
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
 
+    typedef const TYPE CONST_TYPE;
+
     BloombergLP::bslstl::Optional_DataImp<TYPE> X;
     ASSERT(!X.hasValue());
 
@@ -945,9 +917,53 @@ void TestDriver<TYPE>::bslstl_optional_test2()
 
     ASSERT(isConstPtr(&val) == isConstPtr(&X.value()));
 
+    BloombergLP::bslstl::Optional_DataImp<CONST_TYPE> CX;
+    CX.emplace(&da, val);
+    ASSERT(isConstPtr(&CX.value()));
+
     X.reset();
     ASSERT(!X.hasValue());
+    CX.reset();
+    ASSERT(!X.hasValue());
+
 }
+
+template <class TYPE>
+void TestDriver<TYPE>::testCase1()
+{
+    // --------------------------------------------------------------------
+    // 'Optional_Data' TEST
+    //  This case exercises the functionality of 'Optional_Data' internal
+    //  class.  'Optional_Data' allows 'bsl::optional' objects to be trivially
+    //  destructible if 'TYPE' is trivially destructible.
+    //
+    // Concerns:
+    //: 1 'Optional_Data<TYPE>' object is trivially destructible if 'TYPE' is
+    //:    trivially destructible.
+    //
+    // Plan:
+    //: 1 Compare 'std::is_trivially_destructible' trait for 'TYPE' and for
+    //:   'Optional_Data<TYPE>'.  In C++03 mode, use
+    //:   'bsl::is_trivially_copyable' trait instead.
+    //
+    // Testing:
+    //   'Optional_Data' class
+    // --------------------------------------------------------------------
+    if (verbose)
+        printf("\n'Optional_Data' TEST"
+               "\n=================== \n");
+
+#ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
+    ASSERT(std::is_trivially_destructible<TYPE>::value ==
+           std::is_trivially_destructible<
+               BloombergLP::bslstl::Optional_Data<TYPE> >::value);
+#else
+    ASSERT(bsl::is_trivially_copyable<TYPE>::value ==
+           bsl::is_trivially_copyable<
+               BloombergLP::bslstl::Optional_Data<TYPE> >::value);
+#endif  // BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
+}
+
 //=============================================================================
 //                              MAIN PROGRAM
 //-----------------------------------------------------------------------------
@@ -976,14 +992,9 @@ int main(int argc, char **argv)
                    "======================="
                    "\n");
 
-        TestDriver<int>::bslstl_optional_test2();
-        TestDriver<MyClass1>::bslstl_optional_test2();
-        TestDriver<MyClass2>::bslstl_optional_test2();
-        TestDriver<MyClass2a>::bslstl_optional_test2();
-        TestDriver<const int>::bslstl_optional_test2();
-        TestDriver<const MyClass1>::bslstl_optional_test2();
-        TestDriver<const MyClass2>::bslstl_optional_test2();
-        TestDriver<const MyClass2a>::bslstl_optional_test2();
+        RUN_EACH_TYPE(TestDriver,
+                      testCase2,
+                      BSLTF_TEMPLATETESTFACILITY_TEST_TYPES_REGULAR);
       } break;
       case 1: {
         // --------------------------------------------------------------------
@@ -997,11 +1008,10 @@ int main(int argc, char **argv)
                    "===================="
                    "\n");
 
-        TestDriver<int>::bslstl_optional_test1();
-        TestDriver<const int>::bslstl_optional_test1();
-        TestDriver<MyClass1>::bslstl_optional_test1();
-        TestDriver<MyClass2>::bslstl_optional_test1();
-        TestDriver<MyClass2a>::bslstl_optional_test1();
+        RUN_EACH_TYPE(TestDriver,
+                      testCase1,
+                      BSLTF_TEMPLATETESTFACILITY_TEST_TYPES_ALL);
+
       } break;
       default: {
         printf("WARNING: CASE `%d' NOT FOUND.\n", test);

--- a/groups/bsl/bslstl/bslstl_optional.t.cpp
+++ b/groups/bsl/bslstl/bslstl_optional.t.cpp
@@ -860,6 +860,7 @@ class TestDriver {
     // type.
   public:
     static void testCase2();
+    static void testCase2_Imp();
         // Optional_DataImp TEST.  The test requires TYPE to be default
         // constructible.
 
@@ -867,9 +868,15 @@ class TestDriver {
         // Optional_Data TEST
 
 };
-
 template <class TYPE>
 void TestDriver<TYPE>::testCase2()
+{
+    testCase2_Imp();
+    TestDriver<const TYPE>::testCase2_Imp();
+
+}
+template <class TYPE>
+void TestDriver<TYPE>::testCase2_Imp()
 {
     // --------------------------------------------------------------------
     // 'Optional_DataImp' TEST
@@ -914,16 +921,9 @@ void TestDriver<TYPE>::testCase2()
     ASSERT(X.hasValue());
     ASSERT(X.value() == val);
     ASSERT(checkAllocator(X, &da));
-
     ASSERT(isConstPtr(&val) == isConstPtr(&X.value()));
 
-    BloombergLP::bslstl::Optional_DataImp<CONST_TYPE> CX;
-    CX.emplace(&da, val);
-    ASSERT(isConstPtr(&CX.value()));
-
     X.reset();
-    ASSERT(!X.hasValue());
-    CX.reset();
     ASSERT(!X.hasValue());
 
 }

--- a/groups/bsl/bslstl/bslstl_optional.t.cpp
+++ b/groups/bsl/bslstl/bslstl_optional.t.cpp
@@ -911,8 +911,6 @@ void TestDriver<TYPE>::testCase2_Imp()
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
 
-    typedef const TYPE CONST_TYPE;
-
     BloombergLP::bslstl::Optional_DataImp<TYPE> X;
     ASSERT(!X.hasValue());
 

--- a/groups/bsl/bslstl/package/bslstl.mem
+++ b/groups/bsl/bslstl/package/bslstl.mem
@@ -23,6 +23,7 @@ bslstl_hashtable
 bslstl_hashtable_test
 bslstl_hashtablebucketiterator
 bslstl_hashtableiterator
+bslstl_inplace
 bslstl_iosfwd
 bslstl_iserrorcodeenum
 bslstl_iserrorconditionenum


### PR DESCRIPTION
adding internal classes of bsl::optional.
These are :
nullopt_t  - std::nullopt_t tag class implementation
inplace_t - std::in_place_t tag class implementation
Optional_OptNoSuchType - type to differentiate an enable_if parameter in constrained functions. This is so expressions like optional(T,{}) never consider a constrained constructor.
Optional_DataImp - a type which prevents UB with const value types by manipulating a non const value type object and providing a const adjusted interface
Optional_Data - a type which makes bsl::optional trivially destructible if value type is trivially destructible

the code has been tested in C++03, C++11 and C++17